### PR TITLE
Dev Kernels 0.2.0: Major Enhancement on Execution Logic and Bug Fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,5 @@
     "files.watcherExclude": {
         "**/target": true
     },
-    "zeppelin.alwaysConnectLastServer": "Yes"
+    "zeppelin.alwaysConnectToTheLastServer": "Yes"
 }

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Zeppelin Extension for Visual Studio Code
 
 A [Visual Studio Code](https://code.visualstudio.com/) extension that provides basic notebook support for language kernels that are supported in [Zeppelin Notebooks](https://zeppelin.apache.org/) today. This is _**NOT a Zeppelin Server or language kernel**_--you must have an Zeppelin Server 0.8.0 or afterwards for note to run properly in VS Code.
+Currently the extension development does not consider notebook permission, version control and cron job. If you believe these are important, please fire an issue.
 
 ## Features
 * Zeppelin notebook file rendered in VS Code, just like juypter notebook does.
-* Paragraph runnable in notebook by communicating with Zeppelin server.
-* Local changes automatically synced with server.
+* Paragraph runnable (either in sequence or in parallel) in notebook, by communicating with Zeppelin server.
+* Local changes automatically synced with server, vice versa.
 
 ## How to Use
 * Install Zeppelin VS Code Extension.
 * Download Zeppelin notebook file (either .json or .zpln) from Zeppelin web server.
 * Rename file suffix into ".zpln" if it is ".json".
 * Open it using VS Code, during first cell run you will be prompted to provide server url and credential.
+* Internally local changes to the notebook are updated to the Zeppelin server in every second,
+  your local notebook will be updated to the server version whenever it is opened or activated.
 * More configurations can be accessed by searching for 'zeppelin' in setting or command palette.
 
 ## Contribution

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zeppelin-vscode",
   "displayName": "Zeppelin Notebook",
   "description": "Apache Zeppelin Notebook Extension for VS Code",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "publisher": "AllenLi1231",
   "author": {
     "name": "Allen Li"

--- a/package.json
+++ b/package.json
@@ -84,12 +84,12 @@
     "configuration": {
       "title": "Zeppelin",
       "properties": {
-        "zeppelin.alwaysConnectLastServer": {
+        "zeppelin.alwaysConnectToTheLastServer": {
           "order": 0,
           "type": [
             "string"
           ],
-          "default": null,
+          "default": "Yes",
           "enum": [
             "Yes",
             "No",
@@ -97,20 +97,38 @@
           ],
           "description": "Specify whether to always try connecting to last used Zeppelin server and unlock notebook subsequently."
         },
-        "zeppelin.autosave.throttleTime": {
+        "zeppelin.autosave.toggleSync": {
           "order": 1,
-          "type": "integer",
+          "type": "boolean",
+          "default": true,
+          "description": "Specify whether to periodically sync notebook with Zeppelin server."
+        },
+        "zeppelin.autosave.syncActiveNotebook": {
+          "order": 2,
+          "type": "boolean",
+          "default": true,
+          "description": "Specify whether to sync notebook with Zeppelin server when active notebook is changed."
+        },
+        "zeppelin.autosave.throttleTime": {
+          "order": 3,
+          "type": "number",
           "default": 1,
           "description": "Set paragraph update delay time (in seconds). Avoid too fast changes of cells causing response pressure on Zeppelin server."
         },
         "zeppelin.autosave.poolingInterval": {
-          "order": 2,
-          "type": "integer",
+          "order": 4,
+          "type": "number",
           "default": 1,
           "description": "Set minimum save interval (in seconds) to Zeppelin server."
         },
+        "zeppelin.trackExecutionInterval": {
+          "order":  5,
+          "type": "number",
+          "default": 1,
+          "description": "Set minimum interval (in seconds) to track execution."
+        },
         "zeppelin.proxy.host": {
-          "order": 3,
+          "order": 6,
           "type": [
             "string"
           ],
@@ -119,7 +137,7 @@
           "description": "Set proxy host for connection with Zeppelin server."
         },
         "zeppelin.proxy.port": {
-          "order": 4,
+          "order": 7,
           "type": [
             "integer"
           ],
@@ -127,7 +145,7 @@
           "description": "Set proxy port for connection with Zeppelin server."
         },
         "zeppelin.proxy.credential.username": {
-          "order": 5,
+          "order": 8,
           "type": [
             "string"
           ],
@@ -135,7 +153,7 @@
           "description": "Specifies proxy authentication for connection with Zeppelin server."
         },
         "zeppelin.proxy.credential.password": {
-          "order": 6,
+          "order": 9,
           "type": [
             "string"
           ],
@@ -143,7 +161,7 @@
           "description": "Specifies proxy authentication for connection with Zeppelin server."
         },
         "zeppelin.proxy.credential.protocol": {
-          "order": 7,
+          "order": 10,
           "type": [
             "string"
           ],

--- a/package.json
+++ b/package.json
@@ -97,32 +97,26 @@
           ],
           "description": "Specify whether to always try connecting to last used Zeppelin server."
         },
-        "zeppelin.autosave.toggleSync": {
-          "order": 1,
-          "type": "boolean",
-          "default": true,
-          "description": "Specify whether to periodically sync notebook with Zeppelin server."
-        },
         "zeppelin.autosave.syncActiveNotebook": {
-          "order": 2,
+          "order": 1,
           "type": "boolean",
           "default": true,
           "description": "Specify whether to sync notebook with Zeppelin server when active notebook is changed."
         },
         "zeppelin.autosave.throttleTime": {
-          "order": 3,
+          "order": 2,
           "type": "number",
           "default": 1,
           "description": "Set paragraph update delay time (in seconds). Avoid too fast changes of cells causing response pressure on Zeppelin server."
         },
         "zeppelin.autosave.poolingInterval": {
-          "order": 4,
+          "order": 3,
           "type": "number",
           "default": 1,
           "description": "Set minimum save interval (in seconds) to Zeppelin server."
         },
         "zeppelin.execution.concurrency": {
-          "order": 5,
+          "order": 4,
           "type": "string",
           "default": "parallel",
           "enum": ["parallel", "sequential"],
@@ -132,13 +126,13 @@
           "description": "Set cell execution concurrency."
         },
         "zeppelin.execution.trackInterval": {
-          "order":  6,
+          "order":  5,
           "type": "number",
           "default": 1,
           "description": "Set minimum interval (in seconds) to track execution."
         },
         "zeppelin.proxy.host": {
-          "order": 7,
+          "order": 6,
           "type": [
             "string"
           ],
@@ -147,7 +141,7 @@
           "description": "Set proxy host for connection with Zeppelin server."
         },
         "zeppelin.proxy.port": {
-          "order": 8,
+          "order": 7,
           "type": [
             "integer"
           ],
@@ -155,7 +149,7 @@
           "description": "Set proxy port for connection with Zeppelin server."
         },
         "zeppelin.proxy.credential.username": {
-          "order": 9,
+          "order": 8,
           "type": [
             "string"
           ],
@@ -163,7 +157,7 @@
           "description": "Specifies proxy authentication for connection with Zeppelin server."
         },
         "zeppelin.proxy.credential.password": {
-          "order": 10,
+          "order": 9,
           "type": [
             "string"
           ],
@@ -171,7 +165,7 @@
           "description": "Specifies proxy authentication for connection with Zeppelin server."
         },
         "zeppelin.proxy.credential.protocol": {
-          "order": 11,
+          "order": 10,
           "type": [
             "string"
           ],

--- a/package.json
+++ b/package.json
@@ -121,14 +121,24 @@
           "default": 1,
           "description": "Set minimum save interval (in seconds) to Zeppelin server."
         },
-        "zeppelin.trackExecutionInterval": {
-          "order":  5,
+        "zeppelin.execution.concurrency": {
+          "order": 5,
+          "type": "string",
+          "default": "parallel",
+          "enum": ["parallel", "sequential"],
+          "enumDescriptions": [
+            "Run muliple cells simultaneously",
+            "Execute in order, new execution will be blocked before previous execution is finished"],
+          "description": "Set cell execution concurrency."
+        },
+        "zeppelin.execution.trackInterval": {
+          "order":  6,
           "type": "number",
           "default": 1,
           "description": "Set minimum interval (in seconds) to track execution."
         },
         "zeppelin.proxy.host": {
-          "order": 6,
+          "order": 7,
           "type": [
             "string"
           ],
@@ -137,7 +147,7 @@
           "description": "Set proxy host for connection with Zeppelin server."
         },
         "zeppelin.proxy.port": {
-          "order": 7,
+          "order": 8,
           "type": [
             "integer"
           ],
@@ -145,14 +155,6 @@
           "description": "Set proxy port for connection with Zeppelin server."
         },
         "zeppelin.proxy.credential.username": {
-          "order": 8,
-          "type": [
-            "string"
-          ],
-          "default": null,
-          "description": "Specifies proxy authentication for connection with Zeppelin server."
-        },
-        "zeppelin.proxy.credential.password": {
           "order": 9,
           "type": [
             "string"
@@ -160,8 +162,16 @@
           "default": null,
           "description": "Specifies proxy authentication for connection with Zeppelin server."
         },
-        "zeppelin.proxy.credential.protocol": {
+        "zeppelin.proxy.credential.password": {
           "order": 10,
+          "type": [
+            "string"
+          ],
+          "default": null,
+          "description": "Specifies proxy authentication for connection with Zeppelin server."
+        },
+        "zeppelin.proxy.credential.protocol": {
+          "order": 11,
           "type": [
             "string"
           ],

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
             "No",
             "Never"
           ],
-          "description": "Specify whether to always try connecting to last used Zeppelin server and unlock notebook subsequently."
+          "description": "Specify whether to always try connecting to last used Zeppelin server."
         },
         "zeppelin.autosave.toggleSync": {
           "order": 1,
@@ -183,11 +183,6 @@
       {
         "command": "zeppelin-vscode.setZeppelinCredential",
         "title": "Zeppelin: Set Zeppelin Credential (username and password)"
-      },
-      {
-        "command": "zeppelin-vscode.unlockCurrentNotebook",
-        "title": "Zeppelin: Unlock Current Notebook by Connecting to Server",
-        "enablement": "resourceExtname == .zpln && !activeEditorIsReadonly"
       }
     ],
     "menus": {
@@ -201,10 +196,6 @@
         },
         {
           "command": "zeppelin-vscode.setZeppelinCredential"
-        },
-        {
-          "command": "zeppelin-vscode.unlockCurrentNotebook",
-          "when": "resourceExtname == .zpln && !activeEditorIsReadonly"
         }
       ]
     }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -277,7 +277,7 @@ export class NotebookService extends BasicService{
 
     getParagraphInfo(noteId: string, paragraphId: string) {
         return this.session.get(
-            `/api/notebook/${noteId}/${paragraphId}`
+            `/api/notebook/${noteId}/paragraph/${paragraphId}`
         );
     }
 

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -86,6 +86,20 @@ class BasicService {
         );
     }
 
+    resetCancelToken() {
+        this.cancelTokenSource = axios.CancelToken.source();
+        this.session.defaults.cancelToken = this.cancelTokenSource.token;
+    }
+
+    getCancelToken() {
+        return this.cancelTokenSource;
+    }
+
+    cancelConnect() {
+        this.getCancelToken().cancel();
+        this.resetCancelToken();
+    }
+
     async login(username: string, password: string) {
         let res = await this.session.post(
             '/api/login',

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -51,11 +51,17 @@ class BasicService {
       // create request session based on config
       this.session.interceptors.response.use(
             (response) => {
-                logDebug(response);
+                logDebug(
+                    `api: ${response.request.method} ${response.request.path}`,
+                    response.data
+                );
                 return response;
             },
             (error) => {
-                logDebug(error);
+                logDebug(
+                    `api error: ${error.request.method} ${error.request.path}`,
+                    error
+                );
                 if (error.code === "ERR_CANCELED") {
                     return error;
                 }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -56,11 +56,15 @@ class BasicService {
             },
             (error) => {
                 logDebug(error);
+                if (error.code === "ERR_CANCELED") {
+                    return error;
+                }
+
                 let url = error.request?.path;
 
                 if (!error.response) {
                     window.showErrorMessage(`Error calling ${url}: ${error.message}
-                        Possibly due to local network issue`);
+                        possibly due to local network issue`);
                 }
                 else if (error.response?.status === 401) {
                     window.showWarningMessage(

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -37,7 +37,7 @@ export function formatURL(url: string): string {
 
 export function logDebug(item: string | any, ...optionalParams: any[]) {
     if (DEBUG_MODE) {
-        console.log(item, optionalParams);
+        console.log(`Zeppelin ${item}`, optionalParams);
     }
 }
 

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -49,6 +49,7 @@ export function getProxy() {
         proxy = {
             host: config.get('proxy.host', ''),
             port: config.get('proxy.port', 0),
+            protocol: config.get('proxy.protocol')
         };
         if (!!config.get('proxy.credential.username')) {
             proxy["auth"] = {

--- a/src/common/dataStructure.ts
+++ b/src/common/dataStructure.ts
@@ -5,9 +5,9 @@ import { Mutex } from "./mutex";
 export interface NoteData {
 	angularObjects?: AngularObjects;
 	config?: NotebookConfig;
-	id: string;
+	id?: string;
 	info?: NoteInfo;
-    name: string;
+    name?: string;
     noteForms?: any;
     noteParams?: any;
     paragraphs?: ParagraphData[];

--- a/src/common/dataStructure.ts
+++ b/src/common/dataStructure.ts
@@ -29,10 +29,12 @@ export interface ParagraphData {
     config: ParagraphConfig;
     dateCreated?: string;
     dateUpdated?: string;
+    dateFinished?: string;
     errorMessage?: string;
     focus?: boolean,
-    id?: string;
+    id: string;
     jobName?: string;
+    progress?: Number;
     progressUpdateIntervalMs?: number;
     settings?: ParagraphSetting;
     results?: ParagraphResult;

--- a/src/common/dataStructure.ts
+++ b/src/common/dataStructure.ts
@@ -1,3 +1,5 @@
+import { Mutex } from "./mutex";
+
 // the Zeppelin note is basically a json file
 // containing note and paragraph information
 export interface NoteData {
@@ -8,7 +10,8 @@ export interface NoteData {
     name: string;
     noteForms?: any;
     noteParams?: any;
-    paragraphs: ParagraphData[];
+    paragraphs?: ParagraphData[];
+    mutex?: Mutex;
 }
 
 export interface AngularObjects {

--- a/src/common/dataStructure.ts
+++ b/src/common/dataStructure.ts
@@ -68,7 +68,7 @@ export interface ParagraphSetting {
 
 export interface ParagraphResult {
     code: string;
-    msg: ParagraphResultMsg[]
+    msg?: ParagraphResultMsg[]
 }
 
 export interface ParagraphResultMsg {

--- a/src/common/dataStructure.ts
+++ b/src/common/dataStructure.ts
@@ -29,7 +29,7 @@ export interface NoteInfo {
 }
 
 export interface ParagraphData {
-    config: ParagraphConfig;
+    config?: ParagraphConfig;
     dateCreated?: string;
     dateUpdated?: string;
     dateFinished?: string;
@@ -50,11 +50,11 @@ export interface ParagraphConfig {
     lineNumbers?: boolean;
     colWidth?: number;
     editorMode?: string;
-    editorSetting: {
-        completionKey: string;
-        completionSupport: boolean;
-        editOnDblClick: boolean;
-        language: string;
+    editorSetting?: {
+        completionKey?: string;
+        completionSupport?: boolean;
+        editOnDblClick?: boolean;
+        language?: string;
     },
     enabled?: boolean;
     fontSize?: number;

--- a/src/common/interaction.ts
+++ b/src/common/interaction.ts
@@ -309,7 +309,7 @@ export async function promptAlwaysConnect() {
 		"Yes", "No", "Never"
 	);
 	let config = vscode.workspace.getConfiguration('zeppelin');
-	config.update('alwaysConnectLastServer', selection);
+	config.update('alwaysConnectToTheLastServer', selection);
 	return selection;
 }
 

--- a/src/common/interaction.ts
+++ b/src/common/interaction.ts
@@ -349,7 +349,7 @@ export async function promptCreateNotebook(
 		// remove duplicated paths and sort the rests
 		visiblePaths = [...new Set(visiblePaths)].sort();
 	} catch (err) {
-		logDebug(err);
+		logDebug("error in promptCreateNotebook", err);
 		return false;
 	}
 

--- a/src/common/mutex.ts
+++ b/src/common/mutex.ts
@@ -26,6 +26,10 @@ export class Mutex {
      * Wait until the lock is acquired.
      * @returns A function that releases the acquired lock.
      */
+    isLocked() {
+        return this.isLocked;
+    }
+
     acquire() {
         return new Promise<ReleaseFunction>((resolve) => {
             this._queue.push({resolve});

--- a/src/common/mutex.ts
+++ b/src/common/mutex.ts
@@ -1,0 +1,103 @@
+import { time } from "console";
+
+/**
+ * A lock for synchronizing async operations.
+ * Use this to protect a critical section
+ * from getting modified by multiple async operations
+ * at the same time.
+ */
+export class Mutex {
+    /**
+     * When multiple operations attempt to acquire the lock,
+     * this queue remembers the order of operations.
+     */
+    private _queue: {
+        resolve: (release: ReleaseFunction) => void;
+    }[] = [];
+
+    private _isLocked = false;
+    private interval: number;
+
+    constructor (interval?: number){
+        this.interval = interval ?? 0;
+    }
+
+    /**
+     * Wait until the lock is acquired.
+     * @returns A function that releases the acquired lock.
+     */
+    acquire() {
+        return new Promise<ReleaseFunction>((resolve) => {
+            this._queue.push({resolve});
+            this._dispatch();
+        });
+    }
+
+    /**
+     * Enqueue a function to be run serially.
+     * 
+     * This ensures no other functions will start running
+     * until `callback` finishes running.
+     * @param callback Function to be run exclusively.
+     * @returns The return value of `callback`.
+     */
+    async runExclusive<T>(callback: () => Promise<T>) {
+        const release = await this.acquire();
+        try {
+            let res = await callback();
+            if (this.interval > 0) {
+                await timeout(this.interval);
+            }
+            return res;
+        } finally {
+            release();
+        }
+    }
+
+    /**
+     * Check the availability of the resource
+     * and provide access to the next operation in the queue.
+     *
+     * _dispatch is called whenever availability changes,
+     * such as after lock acquire request or lock release.
+     */
+    private _dispatch() {
+        if (this._isLocked) {
+            // The resource is still locked.
+            // Wait until next time.
+            return;
+        }
+        const nextEntry = this._queue.shift();
+        if (!nextEntry) {
+            // There is nothing in the queue.
+            // Do nothing until next dispatch.
+            return;
+        }
+        // The resource is available.
+        this._isLocked = true; // Lock it.
+        // and give access to the next operation
+        // in the queue.
+        nextEntry.resolve(this._buildRelease());
+    }
+
+    /**
+     * Build a release function for each operation
+     * so that it can release the lock after
+     * the operation is complete.
+     */
+    private _buildRelease(): ReleaseFunction {
+        return () => {
+            // Each release function make
+            // the resource available again
+            this._isLocked = false;
+            // and call dispatch.
+            this._dispatch();
+        };
+    }
+}
+
+type ReleaseFunction = () => void;
+
+function timeout(second: number) {
+    return new Promise(resolve => setTimeout(resolve, second * 1000));
+}

--- a/src/common/parser.ts
+++ b/src/common/parser.ts
@@ -10,7 +10,7 @@ import {
 export function parseParagraphToCellData(
     paragraph: ParagraphData,
 ): vscode.NotebookCellData {
-    let lang: string = paragraph.config.editorSetting.language;
+    let lang = paragraph.config?.editorSetting?.language ?? '';
     // default cell kind is markup language
     let kind: number = mapLanguageKind.get(lang) ?? 1;
     // empty cell could have no text method, while NotebookCellData must have text value,
@@ -160,6 +160,13 @@ export function parseCellToParagraphData(
         : cell.document.languageId;
 
     if (paragraph.id !== undefined) {
+        if (paragraph.config === undefined) {
+            paragraph.config = {"editorSetting": {}};
+        }
+        if (paragraph.config.editorSetting === undefined) {
+            paragraph.config.editorSetting = {};
+        }
+
         paragraph.config.editorSetting.language = languageId;
     }
     else {
@@ -167,13 +174,14 @@ export function parseCellToParagraphData(
             .get("lineNumbers", vscode.TextEditorLineNumbersStyle.Off)
                 !== vscode.TextEditorLineNumbersStyle.Off;
         paragraph.config = {
-            "lineNumbers": paragraph.config.lineNumbers ?? lineNumbers,
+            "lineNumbers": paragraph.config?.lineNumbers ?? lineNumbers,
             "editorSetting": {
                 "language": languageId,
                 "editOnDblClick": false,
                 "completionKey": "TAB",
                 "completionSupport": cell.kind !== 1
-            } };
+            }
+        };
     }
 
     paragraph.results = cell.metadata?.results;

--- a/src/common/parser.ts
+++ b/src/common/parser.ts
@@ -36,11 +36,11 @@ export function parseParagraphResultToCellOutput(
     let encoder = new TextEncoder();
     let textOutput = '', htmlOutput = '', errorOutput = '';
     let imageOutputs: Uint8Array[] = [];
-    for (let msg of results['msg']) {
-        if (msg['type'] === 'HTML') {
+    for (let msg of results.msg ?? []) {
+        if (msg.type === 'HTML') {
             htmlOutput += msg.data;
         }
-        else if (msg['type'] === 'IMG') {
+        else if (msg.type === 'IMG') {
             let data = Uint8Array.from(atob(msg.data), c => c.charCodeAt(0));
             imageOutputs.push(data);
         }

--- a/src/common/parser.ts
+++ b/src/common/parser.ts
@@ -163,8 +163,9 @@ export function parseCellToParagraphData(
         paragraph.config.editorSetting.language = languageId;
     }
     else {
-        let lineNumbers = vscode.workspace.getConfiguration("editor").get("lineNumbers")
-            !== vscode.TextEditorLineNumbersStyle.Off;
+        let lineNumbers = vscode.workspace.getConfiguration("editor")
+            .get("lineNumbers", vscode.TextEditorLineNumbersStyle.Off)
+                !== vscode.TextEditorLineNumbersStyle.Off;
         paragraph.config = {
             "lineNumbers": paragraph.config.lineNumbers ?? lineNumbers,
             "editorSetting": {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -6,7 +6,6 @@ import { ZeppelinSerializer } from './notebookSerializer';
 import { ZeppelinKernel } from './notebookKernel';
 import { NOTEBOOK_SUFFIX, logDebug } from '../common/common';
 import _ = require('lodash');
-import { Mutex } from '../common/mutex';
 
 
 // This method is called when your extension is activated
@@ -53,6 +52,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		if (!note.uri.fsPath.endsWith(NOTEBOOK_SUFFIX)) {
 			return;
 		}
+		logDebug("onDidOpenNotebookDocument:", note);
 
 		// lock file before kernel is able to connected to server
 		// vscode.commands.executeCommand(
@@ -106,6 +106,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			|| !kernel.isActive()) {
 			return;
 		}
+		logDebug("onDidChangeNotebookDocument:", event.notebook);
 
 		// modify paragraph on remote
 		for (let cellChange of event.cellChanges) {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -80,7 +80,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		// user selection could be undefined (user never determined),
 		// Yes, No or Never (user specified)
 		let config = vscode.workspace.getConfiguration('zeppelin');
-		let selection = config.get('alwaysConnectLastServer');
+		let selection = config.get('alwaysConnectToTheLastServer');
 		if (selection === 'Never') {
 			return;
 		}

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -822,7 +822,7 @@ export class ZeppelinKernel {
             let paragraph = await this.getParagraphInfo(cell);
 
             let startTime: number;
-            if ((paragraph.status !== "RUNNING") || (cell.metadata.status !== "PENDING")) {
+            if ((paragraph.status !== "RUNNING") && (cell.metadata.status !== "PENDING")) {
                 this._runParagraph(cell, false);
                 startTime = Date.now();
             }

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -701,7 +701,11 @@ export class ZeppelinKernel {
             cell.notebook.metadata.id, cell.metadata.id, sync
         );
         if (!sync) {
-            return res?.data;
+            return res?.data ?? [];
+        }
+
+        if (!res?.data.body) {
+            return [];
         }
 
         let paragraphResult = <ParagraphResult> res?.data.body;
@@ -768,9 +772,9 @@ export class ZeppelinKernel {
         try {
             await this.instantUpdatePollingParagraphs();
 
-            let cellOutput = await this._runParagraph(cell, true);
             execution.start(Date.now());
-            if (cellOutput.length > 0) {
+            let cellOutput = await this._runParagraph(cell, true);
+            if (cellOutput && cellOutput.length > 0) {
                 execution.replaceOutput(new vscode.NotebookCellOutput(cellOutput));
             }
             else {

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -9,7 +9,7 @@ import { EXTENSION_NAME,
     getProxy
 } from '../common/common';
 import { NoteData, ParagraphData, ParagraphResult } from '../common/dataStructure';
-import { showQuickPickURL, doLogin } from '../common/interaction';
+import { showQuickPickURL, doLogin, promptZeppelinServerURL } from '../common/interaction';
 import { parseParagraphToCellData, parseParagraphResultToCellOutput 
 } from '../common/parser';
 import { Mutex } from '../common/mutex';
@@ -676,17 +676,24 @@ export class ZeppelinKernel {
         return cellOutput;
     }
 
-    private _executeAll(
+    private async _executeAll(
         cells: vscode.NotebookCell[],
         _notebook: vscode.NotebookDocument,
         _controller: vscode.NotebookController
-        ): void {
+        ) {
+        if (!this.isActive()) {
+            promptZeppelinServerURL(this);
+        }
         for (let cell of cells) {
 			this._doExecutionAsync(cell);
 		}
 	}
 
     private async _interruptAll(note: vscode.NotebookDocument) {
+        if (!this.isActive()) {
+            return;
+        }
+
         await this.instantUpdatePollingParagraphs();
 
         let res = await this.getService()?.stopAll(note.metadata.id);

--- a/src/extension/notebookSerializer.ts
+++ b/src/extension/notebookSerializer.ts
@@ -15,10 +15,6 @@ export class ZeppelinSerializer implements vscode.NotebookSerializer {
 	): Promise<vscode.NotebookData> {
 
 		var contents = new TextDecoder().decode(content);
-		let reEmpty = new RegExp('^[\s\n\t\r]*$');
-		if (reEmpty.test(contents)) {
-			logDebug(contents);
-		}
 
 		let raw: NoteData | undefined;
 		try {
@@ -28,7 +24,9 @@ export class ZeppelinSerializer implements vscode.NotebookSerializer {
 			throw err;
 		}
 
-		const cells = raw.paragraphs.map(parseParagraphToCellData);
+		const cells = raw.paragraphs
+						? raw.paragraphs.map(parseParagraphToCellData)
+						: [];
 
 		let note = new vscode.NotebookData(cells);
 		note.metadata = raw;

--- a/src/extension/notebookSerializer.ts
+++ b/src/extension/notebookSerializer.ts
@@ -15,14 +15,21 @@ export class ZeppelinSerializer implements vscode.NotebookSerializer {
 		_token: vscode.CancellationToken
 	): Promise<vscode.NotebookData> {
 
-		var contents = new TextDecoder().decode(content);
+		let raw: NoteData;
 
-		let raw: NoteData | undefined;
-		try {
-			raw = <NoteData>JSON.parse(contents);
-		} catch(err) {
-			logDebug("error serializing note to JSON", err);
-			throw err;
+		var contents = new TextDecoder().decode(content);
+		let reEmpty = new RegExp('^[\s\n\t\r]*$');
+		if (reEmpty.test(contents)) {
+			logDebug(contents);
+			raw = {};
+		}
+		else {
+			try {
+				raw = <NoteData>JSON.parse(contents);
+			} catch(err) {
+				logDebug("error serializing note file to JSON", err);
+				throw err;
+			}
 		}
 		// raw.mutex = new Mutex();
 

--- a/src/extension/notebookSerializer.ts
+++ b/src/extension/notebookSerializer.ts
@@ -5,6 +5,7 @@ import {
 	parseCellToParagraphData
 } from '../common/parser';
 import { NoteData } from '../common/dataStructure';
+// import { Mutex } from '../common/mutex';
 
 
 export class ZeppelinSerializer implements vscode.NotebookSerializer {
@@ -23,6 +24,7 @@ export class ZeppelinSerializer implements vscode.NotebookSerializer {
 			logDebug("error serializing note to JSON", err);
 			throw err;
 		}
+		// raw.mutex = new Mutex();
 
 		const cells = raw.paragraphs
 						? raw.paragraphs.map(parseParagraphToCellData)


### PR DESCRIPTION
### Added
- Notebook cells now can run in parallel, and user can toggle run mode, either in parallel or sequential, in settings.
- Previously local notebook changes will be periodically updated to server, but not vice versa. Now notebook can be updated to its server version whenever it is opened or corresponding window is activated.

### Fixed
- [Missing proxy credential protocol setting](https://github.com/allen-li1231/zeppelin-vscode/commit/fa5ad8ea58ba24a1eaec41c570aa0d9027a79973)
- [Bug that causes code interrupt to fail the extension](https://github.com/allen-li1231/zeppelin-vscode/commit/692d1576e2318e177051d3f1e92ee3512bc8e007).
- [Bug that causes extension to fail when interrupting note](https://github.com/allen-li1231/zeppelin-vscode/commit/96cda9e66ba079711458cafcb5528ec482a52c7b).
- [Bug that causes tracking on cell execution to be falsely ended when paragraph run status is pending](https://github.com/allen-li1231/zeppelin-vscode/commit/f61c9e9b493e2ec7d307780ad7d3aef4daf7a54a).
- [Bug that causes error output when execution an empty cell](https://github.com/allen-li1231/zeppelin-vscode/commit/8ad8d3b0b97c4b7f0b63f84c6dc97eddcc88684d)

### Changed
- [Remove locking zpln files as it causes misunderstanding and potentially causes problem when multiple notebooks are opened](https://github.com/allen-li1231/zeppelin-vscode/commit/b214b94301bfcf1699eb3f7fc6adfc31c0dcd29e)