### PR TITLE
Hot Fix on Wrong Password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,3 +180,8 @@ All notable changes to the "zeppelin-vscode" extension will be documented in thi
 ## [0.2.11] - 2025-01-04
 ### Fixed
 [Add missed parameter (rejectUnauthorized) in https agent](https://github.com/allen-li1231/zeppelin-vscode/commit/6acebf2f56ab10d208b3d34dcb4c09bab3f368d0).
+
+## [0.2.12] - 2025-01-14
+### Fixed
+Wrong password even if provided correctly for [#15].
+Zeppelin credentials not prompted as expected when Zeppelin notebook is not opened.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zeppelin-vscode",
   "displayName": "Zeppelin Notebook",
   "description": "Apache Zeppelin Notebook Extension for VS Code",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "publisher": "AllenLi1231",
   "author": {
     "name": "Allen Li"

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -139,8 +139,8 @@ class BasicService {
         let res = await this.session.post(
             '/api/login',
             {
-                userName: encodeURIComponent(username),
-                password: encodeURIComponent(password)
+                userName: username,
+                password: password
             },
             {
                 withCredentials: true,

--- a/src/common/interaction.ts
+++ b/src/common/interaction.ts
@@ -468,16 +468,19 @@ export async function promptZeppelinServerURL(
 export async function promptZeppelinCredential(kernel: ZeppelinKernel) {
 	return mutex.runExclusive(async () => {
 	let note = vscode.window.activeNotebookEditor?.notebook;
-	if (note === undefined) {
-		return;
-	}
-
 	let baseURL = kernel.getContext().workspaceState.get(
 		'currentZeppelinServerURL', undefined
 	);
+
+	if (note === undefined) {
+		kernel.deactivate();
+		await kernel.getContext().secrets.delete('zeppelinUsername');
+		kernel.checkInService(baseURL);
+		return;
+	}
+
 	// remove username so login procedure could be triggered
 	await kernel.getContext().secrets.delete('zeppelinUsername');
-	kernel.deactivate();
 
 	// task when remote server is connectable.
 	kernel.checkInService(baseURL, async () => {


### PR DESCRIPTION
### Fixed
Wrong password even if provided correctly for [#15].
Zeppelin credentials not prompted as expected when Zeppelin notebook is not opened.