### PR TITLE
Multi-level Logging, Re-login and Auto-detect Cell Language From Magic Commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,26 @@
           "default": 5,
           "description": "Set minimum interval (in seconds) to track interpreter status."
         },
+        "zeppelin.logLevel": {
+          "order": 7,
+          "type": "string",
+          "default": "info",
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Verbose internal tracing (mutex locks, paragraph registration, etc.)",
+            "Lifecycle events and notable actions (activation, sync, cache population)",
+            "Recoverable problems and skipped operations",
+            "Failures requiring user attention",
+            "Disable all logging"
+          ],
+          "description": "Controls the verbosity of Zeppelin extension logging in the Output panel."
+        },
         "zeppelin.proxy.loadEnvironmentVariable": {
           "order": 7,
           "type": "boolean",

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { window } from 'vscode';
-import { logDebug, formatURL, reCookies } from './common';
+import { formatURL, reCookies } from './common';
+import { logger } from './logger';
 import {
     ParagraphData,
     ParagraphConfig
@@ -57,7 +58,7 @@ class BasicService {
       // create request session based on config
       this.session.interceptors.response.use(
             (response) => {
-                logDebug(
+                logger.debug(
                     `api: ${response.request.method} ${response.request.path}`,
                     response.data
                 );
@@ -68,7 +69,7 @@ class BasicService {
                     return error;
                 }
 
-                logDebug(
+                logger.error(
                     `api error: ${error.request.method} ${error.request.path}`,
                     error
                 );
@@ -86,7 +87,7 @@ class BasicService {
                 }
                 else if (error.response?.status === 302) {
                     const redirectUrl = error.response.headers.location;
-                    logDebug(`Redirected access from ${url} to ${redirectUrl}`);
+                    logger.warn(`Redirected access from ${url} to ${redirectUrl}`);
                     if (redirectUrl && redirectUrl.endsWith('/api/login')) {
                         this._sessionExpired = true;
                         this.onSessionExpired?.();
@@ -98,7 +99,7 @@ class BasicService {
                     );
                 }
                 else if (error.response?.status === 404) {
-                    logDebug(`Resource '${error.request.path}' not found`);
+                    logger.warn(`Resource '${error.request.path}' not found`);
                 }
                 else if (error.response?.status !== 403
                         && error.response.data.exception !== 'UnavailableSecurityManagerException') {
@@ -158,6 +159,7 @@ class BasicService {
     }
 
     async anonymousLogin() {
+        logger.info(`anonymousLogin: attempting anonymous login to ${this.baseURL}`);
         let res = await this.session.get(
             '/api/security/ticket',
             {
@@ -174,6 +176,7 @@ class BasicService {
         }
 
         this._sessionExpired = false;
+        logger.info("anonymousLogin: success");
         // store cookies to default headers
         if (res.headers['set-cookie']) {
             for (let cookie of res.headers['set-cookie']) {
@@ -189,6 +192,7 @@ class BasicService {
     }
 
     async login(username: string, password: string) {
+        logger.info(`login: attempting login for user '${username}' to ${this.baseURL}`);
         let res = await this.session.post(
             '/api/login',
             {
@@ -209,6 +213,7 @@ class BasicService {
         }
 
         this._sessionExpired = false;
+        logger.info(`login: success for user '${username}'`);
         // store cookies to default headers
         if (res.headers['set-cookie']) {
             for (let cookie of res.headers['set-cookie']) {

--- a/src/common/common.d.ts
+++ b/src/common/common.d.ts
@@ -1,4 +1,4 @@
-export declare const DEBUG_MODE = false;
-export declare const NAME = "zeppelin-notebook";
+export declare const EXTENSION_NAME: string;
 export declare function formatURL(url: string): string;
-export declare function logDebug(item: string | any): void;
+/** @deprecated Use `logger.debug()`, `logger.info()`, `logger.warn()`, or `logger.error()` instead. */
+export declare function logDebug(item: string | any, ...optionalParams: any[]): void;

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -1,7 +1,7 @@
 import { ExtensionContext, workspace, Uri } from "vscode";
 import { AxiosProxyConfig } from 'axios';
 
-export const DEBUG_MODE = true;
+import { logger } from './logger';
 
 export const EXTENSION_NAME = 'zeppelin-notebook';
 export const NOTEBOOK_SUFFIX = '.zpln';
@@ -125,10 +125,11 @@ export function formatURL(url: string): string {
     return url;
 }
 
+/**
+ * @deprecated Use `logger.debug()`, `logger.info()`, `logger.warn()`, or `logger.error()` instead.
+ */
 export function logDebug(item: string | any, ...optionalParams: any[]) {
-    if (DEBUG_MODE) {
-        console.log(`Zeppelin ${item}`, optionalParams);
-    }
+    logger.debug(String(item), ...optionalParams);
 }
 
 export function getProxy() {

--- a/src/common/interaction.ts
+++ b/src/common/interaction.ts
@@ -1,6 +1,7 @@
 import { AxiosError } from 'axios';
 import { NotebookService } from './api';
-import { reURL, logDebug } from './common';
+import { reURL } from './common';
+import { logger } from './logger';
 import * as vscode from 'vscode';
 import { ZeppelinKernel } from '../extension/notebookKernel';
 import { parseCellToParagraphData } from './parser';
@@ -35,7 +36,7 @@ export async function showInputURL() {
 	if (label === undefined) {
 		return undefined;
 	}
-	logDebug(`received server name: ${label}`);
+	logger.debug(`received server name: ${label}`);
 
 	// create dict and return as result
 	const result = {
@@ -101,7 +102,7 @@ export async function showQuickPickURL(
 		if (picked.label === `$(server-environment)Existing`) {
 			context.workspaceState.update('currentZeppelinServerName', undefined);
 			context.workspaceState.update('currentZeppelinServerURL', '');
-			let pickedPair = await showInputURL().catch(logDebug);
+			let pickedPair = await showInputURL().catch(logger.debug);
 			if (!pickedPair) {
 				// user aborted, pass
 				quickPick.hide();
@@ -121,12 +122,12 @@ export async function showQuickPickURL(
 		}
 		else {
 			if (!picked.description) {
-				logDebug('got unexpected empty url from pickItem.description');
+				logger.debug('got unexpected empty url from pickItem.description');
 				quickPick.hide();
 				return;
 			}
 
-			logDebug("URL picked from history", picked);
+			logger.debug("URL picked from history", picked);
 			pickedLabel = picked.label;
 			pickedURL = picked.description;
 			urlHistory = urlHistory.filter(pair => pair.url !== pickedURL);
@@ -191,7 +192,7 @@ export async function showQuickPickURL(
 		];
 		});
 
-	logDebug("showing quick-pick URLs", quickPick);
+	logger.debug("showing quick-pick URLs", quickPick);
 	quickPick.show();
 }
 
@@ -392,7 +393,7 @@ export async function promptCreateNotebook(
 		// remove duplicated paths and sort the rests
 		visiblePaths = [...new Set(visiblePaths)].sort();
 	} catch (err) {
-		logDebug("error in promptCreateNotebook", err);
+		logger.debug("error in promptCreateNotebook", err);
 		return false;
 	}
 
@@ -426,7 +427,7 @@ export async function promptCreateNotebook(
 				}
 			}
 			catch (err) {
-				logDebug("error create/import note", err);
+				logger.debug("error create/import note", err);
 				quickPick.hide();
 				return;
 			}
@@ -456,7 +457,7 @@ export async function promptCreateNotebook(
 		quickPick.dispose();
 	}));
 
-	logDebug("showing quick-pick remote paths", quickPick);
+	logger.debug("showing quick-pick remote paths", quickPick);
 	quickPick.show();
 
 	return true;
@@ -554,11 +555,11 @@ Do you wish to create the paragraph?`,
 	}
 
 	try {
-		logDebug("promptCreateParagraph", cell);
+		logger.debug("promptCreateParagraph", cell);
 		return await kernel.createParagraph(cell);
 	}
 	catch (err) {
-		logDebug("promptCreateParagraph abort");
+		logger.debug("promptCreateParagraph abort");
 		return;
 	}
 }

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+
+export enum LogLevel {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+    Off = 4,
+}
+
+const LOG_LEVEL_NAMES: Record<LogLevel, string> = {
+    [LogLevel.Debug]: 'DEBUG',
+    [LogLevel.Info]: 'INFO',
+    [LogLevel.Warn]: 'WARN',
+    [LogLevel.Error]: 'ERROR',
+    [LogLevel.Off]: 'OFF',
+};
+
+export function parseLogLevel(value: string | undefined): LogLevel {
+    switch (value?.toLowerCase()) {
+        case 'debug': return LogLevel.Debug;
+        case 'info': return LogLevel.Info;
+        case 'warn': return LogLevel.Warn;
+        case 'error': return LogLevel.Error;
+        case 'off': return LogLevel.Off;
+        default: return LogLevel.Info;
+    }
+}
+
+class Logger {
+    private _channel: vscode.OutputChannel | undefined;
+    private _level: LogLevel = LogLevel.Info;
+
+    /** Lazily create the output channel so tests that never call log methods don't need it. */
+    private _getChannel(): vscode.OutputChannel {
+        if (!this._channel) {
+            this._channel = vscode.window.createOutputChannel('Zeppelin Notebook');
+        }
+        return this._channel;
+    }
+
+    setLevel(level: LogLevel) { this._level = level; }
+    getLevel(): LogLevel { return this._level; }
+
+    debug(msg: string, ...args: any[]) { this._log(LogLevel.Debug, msg, args); }
+    info(msg: string, ...args: any[])  { this._log(LogLevel.Info, msg, args); }
+    warn(msg: string, ...args: any[])  { this._log(LogLevel.Warn, msg, args); }
+    error(msg: string, ...args: any[]) { this._log(LogLevel.Error, msg, args); }
+
+    private _log(level: LogLevel, msg: string, args: any[]) {
+        if (level < this._level) { return; }
+
+        const prefix = LOG_LEVEL_NAMES[level];
+        const timestamp = new Date().toISOString();
+        const formatted = args.length > 0
+            ? `[${timestamp}] [${prefix}] ${msg} ${args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ')}`
+            : `[${timestamp}] [${prefix}] ${msg}`;
+
+        // Write to VS Code Output panel
+        this._getChannel().appendLine(formatted);
+
+        // Mirror to developer console
+        if (level >= LogLevel.Error) {
+            console.error(formatted, ...args);
+        } else if (level >= LogLevel.Warn) {
+            console.warn(formatted, ...args);
+        } else {
+            console.log(formatted, ...args);
+        }
+    }
+
+    dispose() {
+        this._channel?.dispose();
+        this._channel = undefined;
+    }
+}
+
+/** Singleton logger instance used throughout the extension. */
+export const logger = new Logger();

--- a/src/common/parser.ts
+++ b/src/common/parser.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
+import { logger } from './logger';
 import {
     mapLanguage,
     mapLanguageKind,
     mapZeppelinLanguage,
     reInterpreter,
-    logDebug
 } from '../common/common';
 import {
     ParagraphData,
@@ -135,7 +135,7 @@ export function parseCellOutputsToParagraphResult(
                 outputContents = new TextDecoder().decode(output.data);
             } catch(err) {
                 // pass
-                logDebug("error in decoding output data", err);
+                logger.error("error in decoding output data", err);
                 throw err;
             }
 
@@ -171,7 +171,7 @@ export function parseCellOutputsToParagraphResult(
                     type: msgType
                 });
             } catch(err) {
-                logDebug("error in parsing output countents to JSON", err);
+                logger.error("error in parsing output countents to JSON", err);
                 throw err;
             }
         }

--- a/src/common/parser.ts
+++ b/src/common/parser.ts
@@ -144,21 +144,27 @@ export function parseCellOutputsToParagraphResult(
                     case 'text/plain': 
                         code = 'SUCCESS';
                         msgType = 'TEXT';
+                        break;
                     case 'text/html': 
                         code = 'SUCCESS';
                         msgType = 'HTML';
+                        break;
                     case 'application/vnd.code.notebook.stdout': 
                         code = 'SUCCESS';
                         msgType = 'TEXT';
+                        break;
                     case 'application/vnd.code.notebook.stderr': 
                         code = 'ERROR';
                         msgType = 'TEXT';
+                        break;
                     case 'application/vnd.code.notebook.error': 
                         code = 'ERROR';
                         msgType = 'TEXT';
+                        break;
                     default:
                         code = 'SUCCESS';
                         msgType = 'TEXT';
+                        break;
                 }
                 results.push({
                     data: outputContents,

--- a/src/common/parser.ts
+++ b/src/common/parser.ts
@@ -23,7 +23,7 @@ export function parseCellInterpreter(
     }
 
     let interpreterId = interpreterIds[1];
-    if (!!return_full) {
+    if (!return_full) {
         let rootIdx = interpreterId.indexOf('.');
         interpreterId = rootIdx > 0
                         ? interpreterId.slice(0, rootIdx)

--- a/src/component/cellStatusBar.ts
+++ b/src/component/cellStatusBar.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { AxiosError } from 'axios';
 import { ZeppelinKernel } from '../extension/notebookKernel';
-import { logDebug, isLocalNotebookCell } from '../common/common';
+import { isLocalNotebookCell } from '../common/common';
+import { logger } from '../common/logger';
 import { Mutex } from './mutex';
 import { parseCellInterpreter } from '../common/parser';
 
@@ -144,7 +145,7 @@ export class CellStatusProvider implements vscode.NotebookCellStatusBarItemProvi
             var res = await this.kernel.getService()?.getInterpreterSetting(interpreterId);
         }
         catch (error) {
-            logDebug(`error in _updateInterpreterStatus for '${interpreterId}'`);
+            logger.error(`error in _updateInterpreterStatus for '${interpreterId}'`);
             return undefined;
         }
 
@@ -204,7 +205,7 @@ export class CellStatusProvider implements vscode.NotebookCellStatusBarItemProvi
         // async loop don't cause us to read a stale or shifted range list.
         const visibleRanges = [...activeNotebook.visibleRanges];
         const notebook = activeNotebook.notebook;
-            logDebug("doUpdateVisibleCells: updating", visibleRanges);
+            logger.debug("doUpdateVisibleCells: updating", visibleRanges);
 
         for (let range of visibleRanges) {
             if (range.isEmpty) {
@@ -284,7 +285,7 @@ export class CellStatusProvider implements vscode.NotebookCellStatusBarItemProvi
                         // ignore the same error
                         continue;
                     }
-                    logDebug("error in doUpdateVisibleCells:" + err);
+                    logger.error("error in doUpdateVisibleCells:" + err);
                     // trigger cell status bar update
                     await this.kernel.updateCellMetadata(cell, { status });
                 }
@@ -300,7 +301,7 @@ export class CellStatusProvider implements vscode.NotebookCellStatusBarItemProvi
 
     public scheduleTracking() {
         if (this.isTrackingScheduled()) {
-            logDebug("cellStatusBar omits duplicated scheduling");
+            logger.debug("cellStatusBar omits duplicated scheduling");
             return;
         }
 

--- a/src/component/cellStatusBar.ts
+++ b/src/component/cellStatusBar.ts
@@ -285,6 +285,8 @@ export class CellStatusProvider implements vscode.NotebookCellStatusBarItemProvi
                         continue;
                     }
                     logDebug("error in doUpdateVisibleCells:" + err);
+                    // trigger cell status bar update
+                    await this.kernel.updateCellMetadata(cell, { status });
                 }
             }
         }

--- a/src/component/cellStatusBar.ts
+++ b/src/component/cellStatusBar.ts
@@ -285,10 +285,11 @@ export class CellStatusProvider implements vscode.NotebookCellStatusBarItemProvi
                         continue;
                     }
                     logDebug("error in doUpdateVisibleCells:" + err);
-                    // trigger cell status bar update
                 }
             }
         }
+
+        await this.kernel.applyPolledNotebookEdits();
     }
 
     public isTrackingScheduled() {

--- a/src/component/cellStatusBar.ts
+++ b/src/component/cellStatusBar.ts
@@ -37,7 +37,7 @@ export class CellStatusProvider implements vscode.NotebookCellStatusBarItemProvi
 
             // Show sync conflict indicator if present
             if (cell.metadata.syncConflict !== undefined
-                && !this.kernel.editMutex.isLocked()
+                && !this.kernel.isEditLocked()
             ) {
                 const conflictItem = new vscode.NotebookCellStatusBarItem(
                     cell.metadata.resolvingDiff

--- a/src/component/execution.ts
+++ b/src/component/execution.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 import { AxiosError } from 'axios';
 import { Mutex } from './mutex';
 import { Progress } from './superProgress/super-progress';
-import { logDebug, isLocalNotebook } from '../common/common';
+import { isLocalNotebook } from '../common/common';
+import { logger } from '../common/logger';
 import { promptZeppelinServerURL, promptCreateParagraph
 } from '../common/interaction';
 import { parseCellInterpreter,
@@ -112,7 +113,7 @@ export class ZeppelinExecution implements vscode.NotebookCellExecution
     {
         if (this._state !== ZeppelinExecutionState.init)
         {
-            logDebug(
+            logger.debug(
                 "execution skip wrong start call",
                 this._state, this._execution
             );
@@ -134,7 +135,7 @@ export class ZeppelinExecution implements vscode.NotebookCellExecution
     {
         if (this._state !== ZeppelinExecutionState.started)
         {
-            logDebug(
+            logger.debug(
                 "execution skip wrong end call",
                 this._state, this._execution
             );
@@ -215,9 +216,10 @@ export class ExecutionManager
     {
         if (this.isTrackingScheduled())
         {
-            logDebug("executionManager omits duplicated scheduling");
+            logger.debug("executionManager omits duplicated scheduling");
             return;
         }
+        logger.info("executionManager: scheduling execution tracking");
 
         let config = vscode.workspace.getConfiguration('zeppelin');
         let trackExecutionInterval = config.get('execution.trackInterval', 1);
@@ -248,6 +250,7 @@ export class ExecutionManager
 
     public cancelAllExecutions()
     {
+        logger.warn(`cancelAllExecutions: cancelling ${this._mapTrackExecution.size} tracked executions`);
         for (let [_, execution] of this._mapTrackExecution)
         {
             if (execution.state === ZeppelinExecutionState.init)
@@ -302,7 +305,7 @@ export class ExecutionManager
     ) {
         if (execution.cell.index < 0)
         {
-            logDebug(`trackExecution: unregister as cell deleted`, execution);
+            logger.debug(`trackExecution: unregister as cell deleted`, execution);
             this.unregisterTrackExecution(execution);
             return;
         }
@@ -314,7 +317,7 @@ export class ExecutionManager
 
         if (execution.state === ZeppelinExecutionState.resolved)
         {
-            logDebug(`trackExecution: unregister as cell resolved`, execution);
+            logger.debug(`trackExecution: unregister as cell resolved`, execution);
             this.unregisterTrackExecution(execution);
             return;
         }
@@ -326,7 +329,7 @@ export class ExecutionManager
         }
         catch (err)
         {
-            logDebug("error in trackExecution:", err);
+            logger.error("error in trackExecution:", err);
             this.unregisterTrackExecution(execution);
             let cellOutput = new vscode.NotebookCellOutput([
                 vscode.NotebookCellOutputItem.error({
@@ -389,7 +392,7 @@ export class ExecutionManager
             }
             catch (err)
             {
-                logDebug("trackExecution error", err, execution);
+                logger.error("trackExecution error", err, execution);
             }
         }
         else if (paragraph.status !== "PENDING")
@@ -403,14 +406,14 @@ export class ExecutionManager
             }
             catch (err)
             {
-                logDebug("trackExecution error", err, execution);
+                logger.error("trackExecution error", err, execution);
             }
         }
 
         if ((paragraph.status !== "RUNNING")
             && (paragraph.status !== "PENDING"))
         {
-            logDebug(`trackExecution: unregister as not running`, execution);
+            logger.debug(`trackExecution: unregister as not running`, execution);
             this.unregisterTrackExecution(execution);
             execution.end(
                 paragraph.status !== "ERROR", Date.now()
@@ -427,7 +430,7 @@ export class ExecutionManager
 
         for (let [_, execution] of this._mapTrackExecution)
         {
-            logDebug(
+            logger.debug(
                 "_doTrackAllExecution: tracking", execution
             );
             aryExecution.push(this.trackExecution(execution));
@@ -484,15 +487,15 @@ export class ExecutionManager
         let concurrency = config.get('execution.concurrency', 'by interpreter');
         for (let cell of cells)
         {
-            logDebug(`execute in ${concurrency}`, cell);
+            logger.debug(`execute in ${concurrency}`, cell);
             if (cell.index === -1) {
-                logDebug("executeAll skips a deleted cell", cell);
+                logger.debug("executeAll skips a deleted cell", cell);
                 continue;
             }
 
             if (cell.metadata.resolvingDiff || cell.metadata.syncConflict !== undefined)
             {
-                logDebug("executeAll skips a cell in resolving diff", cell);
+                logger.warn("executeAll skips a cell in resolving diff", cell);
                 vscode.window.showWarningMessage(
                     `Please resolve the conflict before executing cell ${cell.index + 1}.`
                 );
@@ -557,7 +560,7 @@ export class ExecutionManager
             execution = new ZeppelinExecution(this.kernel, cell);
         }
         catch (error) {
-            logDebug("_doExecutionSync", error);
+            logger.error("_doExecutionSync", error);
             return false;
         }
 
@@ -637,7 +640,7 @@ export class ExecutionManager
                 || (paragraph.status === "RUNNING")
                 || (cell.metadata.status === "PENDING"))
             {
-                logDebug("_doExecutionAsync omit running/non-existent paragraph",
+                logger.debug("_doExecutionAsync omit running/non-existent paragraph",
                     paragraph);
                 return
             }
@@ -706,7 +709,7 @@ export class ExecutionManager
         if (startTime !== undefined
             || serverCell?.metadata?.status === "RUNNING")
         {
-            logDebug("resumeExecutionStatus resuming", cell);
+            logger.debug("resumeExecutionStatus resuming", cell);
             newExecution.start(startTime);
             this.registerTrackExecution(newExecution);
         }

--- a/src/component/mutex.ts
+++ b/src/component/mutex.ts
@@ -1,4 +1,4 @@
-import { logDebug } from "../common/common";
+import { logger } from "../common/logger";
 
 /**
  * A lock for synchronizing async operations.
@@ -80,7 +80,7 @@ export class Mutex {
         }
         // The resource is available.
         this._isLocked = true; // Lock it.
-        logDebug(`mutex ${this._name} locked`);
+        logger.debug(`mutex ${this._name} locked`);
         // and give access to the next operation
         // in the queue.
         nextEntry.resolve(this._buildRelease());
@@ -96,7 +96,7 @@ export class Mutex {
             // Each release function make
             // the resource available again
             this._isLocked = false;
-            logDebug(`mutex ${this._name} releases`);
+            logger.debug(`mutex ${this._name} releases`);
             // and call dispatch.
             this._dispatch();
         };

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -5,9 +5,9 @@ import * as interact from '../common/interaction';
 import { CellStatusProvider} from '../component/cellStatusBar';
 import { ZeppelinSerializer } from './notebookSerializer';
 import { ZeppelinKernel } from './notebookKernel';
+import { logger, parseLogLevel } from '../common/logger';
 import { EXTENSION_NAME,
 	mapZeppelinLanguage,
-	logDebug,
 	isLocalNotebook,
 	isLocalNotebookCell
 } from '../common/common';
@@ -79,6 +79,23 @@ export async function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
+
+	// Initialize logger level from settings
+	const config = vscode.workspace.getConfiguration('zeppelin');
+	logger.setLevel(parseLogLevel(config.get<string>('logLevel')));
+
+	// React to log-level changes at runtime
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('zeppelin.logLevel')) {
+				const cfg = vscode.workspace.getConfiguration('zeppelin');
+				logger.setLevel(parseLogLevel(cfg.get<string>('logLevel')));
+			}
+		})
+	);
+
+	// Register logger for disposal
+	context.subscriptions.push({ dispose: () => logger.dispose() });
 
 	let kernel = new ZeppelinKernel(context);
 	context.subscriptions.push(kernel);
@@ -222,7 +239,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		if (!isLocalNotebook(note.uri)) {
 			return;
 		}
-		logDebug("onDidOpenNotebookDocument:", note);
+		logger.info("onDidOpenNotebookDocument:", note);
 
 		// lock file before kernel is able to connected to server
 		// vscode.commands.executeCommand(
@@ -280,10 +297,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		// modify paragraph on remote
 		for (let cellChange of event.cellChanges) {
 			if (cellChange.document !== undefined) {
-				logDebug("onDidChangeNotebookDocument: cellChange", cellChange);
+				logger.debug("onDidChangeNotebookDocument: cellChange", cellChange);
 				kernel.registerParagraphUpdate(cellChange.cell);
 				kernel.autoDetectCellLanguage(cellChange.cell).catch(err =>
-					logDebug("autoDetectCellLanguage error", err)
+					logger.warn("autoDetectCellLanguage error", err)
 				);
 			}
 		}
@@ -296,19 +313,19 @@ export async function activate(context: vscode.ExtensionContext) {
 					_.zip(contentChange.addedCells, contentChange.removedCells)) {
 				if (cellAdded?.metadata.id !== undefined
 					&& cellAdded.metadata.id === cellRemoved?.metadata.id) {
-					logDebug("onDidChangeNotebookDocument: cellReplaced", cellAdded);
+					logger.debug("onDidChangeNotebookDocument: cellReplaced", cellAdded);
 					kernel.updateParagraph(cellAdded);
 				}
 				else {
 					// normal add/remove cell registeration
 					if (cellAdded !== undefined) {
-						logDebug("onDidChangeNotebookDocument: cellAdded", cellAdded.index);
+						logger.debug("onDidChangeNotebookDocument: cellAdded", cellAdded.index);
 						// update right away,
 						// otherwise more added cell contaminate the indices
 						kernel.updateParagraph(cellAdded);
 					}
 					if (cellRemoved !== undefined) {
-						logDebug("onDidChangeNotebookDocument: cellRemoved", cellRemoved);
+						logger.debug("onDidChangeNotebookDocument: cellRemoved", cellRemoved);
 						kernel.updateParagraph(cellRemoved);
 					}
 				}
@@ -389,7 +406,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			|| !isLocalNotebook(event.notebook.uri)) {
 			return;
 		}
-		logDebug("onDidChangeActiveNotebookEditor", event);
+		logger.info("onDidChangeActiveNotebookEditor", event);
 
 		if (await kernel.doesNotebookExist(event.notebook)) {
 			let config = vscode.workspace.getConfiguration('zeppelin');
@@ -409,5 +426,5 @@ export async function activate(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 export function deactivate() {
-	logDebug("deactivate");
+	logger.info("deactivate");
 }

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -48,9 +48,10 @@ export class ZeppelinKernel
     >();
     private _mapNotebookEdits = new Map<vscode.NotebookCell, vscode.NotebookEdit[]>();
     private _mapUpdateParagraph = new Map<vscode.NotebookCell, { requestTime: number, baseText: string }>();
-    private _flagRegisterParagraphUpdate = true;
+    private _editWithoutParagraphUpdateDepth = 0;
     private _mapInterpreterCache: Map<string, string> | undefined;
     private _sessionExpiredPromptActive = false;
+    private _activationPromise?: Promise<void>;
 
     public cellStatusBar: CellStatusProvider | undefined = undefined;
 
@@ -110,14 +111,21 @@ export class ZeppelinKernel
             this._executionManager?.scheduleTracking();
             this.cellStatusBar?.scheduleTracking();
 
-            // Populate interpreter cache on activation
-            this.listInterpreters().then(map =>
+            // Populate interpreter cache on activation, tracking the promise
+            // so dispose() can guard against late writes.
+            this._activationPromise = this.listInterpreters().then(map =>
             {
-                this._mapInterpreterCache = map;
-                logDebug("interpreter cache populated", map);
+                if (this._isActive)
+                {
+                    this._mapInterpreterCache = map;
+                    logDebug("interpreter cache populated", map);
+                }
             }).catch(err =>
             {
                 logDebug("failed to populate interpreter cache", err);
+            }).finally(() =>
+            {
+                this._activationPromise = undefined;
             });
         }
         logDebug("activate", this.isActive());
@@ -151,6 +159,7 @@ export class ZeppelinKernel
         this.cellStatusBar?.dispose();
 
         this._mapInterpreterCache = undefined;
+        this._activationPromise = undefined;
 
         this._isActive = false;
         logDebug("activate", this.isActive());
@@ -486,6 +495,14 @@ export class ZeppelinKernel
         }, intervalMs);
     }
 
+    /**
+     * Run a paragraph on the Zeppelin server.
+     *
+     * @param sync  When `true`, waits for completion and returns parsed
+     *              `NotebookCellOutputItem[]`.  When `false`, fires and
+     *              returns the raw response data (caller should poll for
+     *              results via execution tracking).
+     */
     public async runParagraph(cell: vscode.NotebookCell, sync: boolean)
     {
         let res = await this.getService()?.runParagraph(
@@ -526,7 +543,7 @@ export class ZeppelinKernel
 
     public async registerParagraphUpdate(cell: vscode.NotebookCell)
     {
-        if (!this._flagRegisterParagraphUpdate)
+        if (this._editWithoutParagraphUpdateDepth > 0)
         {
             logDebug("registerParagraphUpdate: cell not to be updated", cell);
             return;
@@ -539,13 +556,14 @@ export class ZeppelinKernel
         }
 
         logDebug("registerParagraphUpdate", cell);
-        // Flush any deferred metadata updates so cell.metadata.text is current
-        // before snapshotting baseText. This prevents false sync-conflict
-        // detection when the user rapidly edits and executes a cell.
-        await this.applyPolledNotebookEdits();
 
         return this.updateMutex.runExclusive(async () =>
         {
+            // Flush any deferred metadata updates inside the mutex so
+            // cell.metadata.text is current and the snapshot is atomic
+            // with respect to other updateMutex holders.
+            await this.applyPolledNotebookEdits();
+
             if (!this._mapUpdateParagraph.has(cell))
             {
                 // Snapshot the server text at registration time so we can
@@ -609,10 +627,15 @@ export class ZeppelinKernel
     {
         return this.editMutex.runExclusive(async () =>
         {
-            this._flagRegisterParagraphUpdate = false;
-            let res = await func();
-            this._flagRegisterParagraphUpdate = true;
-            return res;
+            this._editWithoutParagraphUpdateDepth++;
+            try
+            {
+                return await func();
+            }
+            finally
+            {
+                this._editWithoutParagraphUpdateDepth--;
+            }
         });
     }
 
@@ -1191,7 +1214,9 @@ export class ZeppelinKernel
         if (res instanceof AxiosError)
         {
             logDebug("error in updateParagraphConfig", res);
-            await this.updateCellMetadata(cell, {"status": res.response?.status});
+            await this.editWithoutParagraphUpdate(async () => {
+                await this.updateCellMetadata(cell, {"status": res.response?.status});
+            });
             throw res;
         }
 
@@ -1262,6 +1287,14 @@ export class ZeppelinKernel
                 // paragraph has changed independently since the edit was
                 // registered.  If so, flag a sync conflict instead of
                 // blindly overwriting the server version.
+                //
+                // NOTE (TOCTOU): There is an inherent time-of-check to
+                // time-of-use gap between this fetch and the subsequent
+                // updateParagraphConfig/updateParagraphText calls.  The
+                // server paragraph could change again in that window.
+                // True atomic conflict resolution would require server-
+                // side locking or optimistic concurrency (e.g. ETags),
+                // which the Zeppelin REST API does not currently support.
                 let mapEntry = this._mapUpdateParagraph.get(cell);
                 let baseText = mapEntry?.baseText ?? '';
 
@@ -1311,6 +1344,12 @@ export class ZeppelinKernel
                 // retry creating cell
                 return;
             }
+            // Notify the user about the failed update so errors
+            // are not silently swallowed for existing paragraphs.
+            vscode.window.showWarningMessage(
+                `Failed to update paragraph ${cell.metadata.id}: `
+                + `${err instanceof Error ? err.message : err}`
+            );
         }
 
         // unregister cell from poll, as the update is either finished or failed now

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -372,8 +372,8 @@ export class ZeppelinKernel
         if (res instanceof AxiosError)
         {
             vscode.window.showWarningMessage(
-                `Unable to get info for note ${noteId}, ` +
-                res.response ? res.response?.data : `${res.code}: ${res.message}`
+                `Unable to get info for note ${noteId}, `
+                + (res.response ? res.response?.data : `${res.code}: ${res.message}`)
             );
             return;
         }

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -8,9 +8,9 @@ import { EXTENSION_NAME,
     mapLanguageKind,
     mapZeppelinLanguage,
     mapVSCodeLanguage,
-    logDebug,
     getProxy,
     getVersion } from '../common/common';
+import { logger } from '../common/logger';
 import { CellStatusProvider } from '../component/cellStatusBar';
 import { NoteData,
     ParagraphData, ParagraphResult } from '../common/types';
@@ -123,17 +123,17 @@ export class ZeppelinKernel
                 if (this._isActive)
                 {
                     this._mapInterpreterCache = map;
-                    logDebug("interpreter cache populated", map);
+                    logger.info("interpreter cache populated", map);
                 }
             }).catch(err =>
             {
-                logDebug("failed to populate interpreter cache", err);
+                logger.warn("failed to populate interpreter cache", err);
             }).finally(() =>
             {
                 this._activationPromise = undefined;
             });
         }
-        logDebug("activate", this.isActive());
+        logger.info("activate", this.isActive());
         return this.isActive();
     }
 
@@ -167,7 +167,7 @@ export class ZeppelinKernel
         this._activationPromise = undefined;
 
         this._isActive = false;
-        logDebug("activate", this.isActive());
+        logger.info("activate", this.isActive());
         return this.isActive();
     }
 
@@ -195,6 +195,7 @@ export class ZeppelinKernel
 
     setService(baseURL: string)
     {
+        logger.info(`setService: connecting to ${baseURL}`);
         let userAgent = `${EXTENSION_NAME}/${getVersion(this._context)} vscode-extension/${vscode.version}`;
 
         let config = vscode.workspace.getConfiguration('zeppelin');
@@ -219,6 +220,7 @@ export class ZeppelinKernel
         {
             return;
         }
+        logger.warn("session expired — prompting user to re-authenticate");
         this._sessionExpiredPromptActive = true;
 
         // cancel all running executions
@@ -249,6 +251,7 @@ export class ZeppelinKernel
 
     private async _activateService(baseURL: string | undefined)
     {
+        logger.info(`_activateService: baseURL=${baseURL ?? '(none)'}`);
         if (!baseURL)
         {
             return this.deactivate();
@@ -334,7 +337,7 @@ export class ZeppelinKernel
 
         if (res instanceof AxiosError)
         {
-            logDebug("error in createNote", res);
+            logger.error("error in createNote", res);
             if (res.response?.status === 500)
             {
                 vscode.window.showErrorMessage(
@@ -353,7 +356,7 @@ export class ZeppelinKernel
     public async importNote(note: any) {
         let res = await this._service?.importNote(note);
 
-        logDebug("error in importNote", res);
+        logger.debug("importNote response", res);
         if (res instanceof AxiosError)
         {
             return undefined;
@@ -384,7 +387,7 @@ export class ZeppelinKernel
         }
         else if (res?.status === 500 || res?.status === 404)
         {
-            logDebug("error in getNoteInfo", res);
+            logger.error("error in getNoteInfo", res);
             vscode.window.showErrorMessage(
                 `Unable to get note info: '${noteId}' doesn't exist on the server`);
             return;
@@ -467,7 +470,7 @@ export class ZeppelinKernel
             }
             else
             {
-                logDebug(
+                logger.debug(
                     `Unable to get paragraph info ${cell.metadata.id} 
                     in note '${cell.notebook.metadata.name}'`, res
                 );
@@ -479,6 +482,7 @@ export class ZeppelinKernel
             paragraph = res?.data.body ?? res?.data;
         }
 
+        logger.debug(`getParagraphInfo: got paragraph ${cell.metadata.id}, status=${paragraph.status}`);
         this.pollUpdateCellMetadata(cell, paragraph);
         return paragraph;
     }
@@ -550,17 +554,17 @@ export class ZeppelinKernel
     {
         if (this._editWithoutParagraphUpdateDepth > 0)
         {
-            logDebug("registerParagraphUpdate: cell not to be updated", cell);
+            logger.debug("registerParagraphUpdate: cell not to be updated", cell);
             return;
         }
 
         if (cell.metadata.resolvingDiff)
         {
-            logDebug("registerParagraphUpdate: cell is resolving diff, skipped", cell);
+            logger.warn("registerParagraphUpdate: cell is resolving diff, skipped", cell);
             return;
         }
 
-        logDebug("registerParagraphUpdate", cell);
+        logger.debug("registerParagraphUpdate", cell);
 
         return this._updateMutex.runExclusive(async () =>
         {
@@ -598,7 +602,7 @@ export class ZeppelinKernel
      */
     public async unregisterParagraphUpdate(cell: vscode.NotebookCell)
     {
-        logDebug("unregisterParagraphUpdate", cell);
+        logger.debug("unregisterParagraphUpdate", cell);
         return this._updateMutex.runExclusive(async () =>
         {
             return this._mapUpdateParagraph.delete(cell);
@@ -611,12 +615,12 @@ export class ZeppelinKernel
      */
     private _unregisterParagraphUpdateDirect(cell: vscode.NotebookCell)
     {
-        logDebug("_unregisterParagraphUpdateDirect", cell);
+        logger.debug("_unregisterParagraphUpdateDirect", cell);
         return this._mapUpdateParagraph.delete(cell);
     }
 
     public async updatePollingParagraphsDirect() {
-        logDebug("updatePollingParagraphsDirect", this._mapUpdateParagraph);
+        logger.debug("updatePollingParagraphsDirect", this._mapUpdateParagraph);
         // let notebookCells = Array.from(this._mapUpdateParagraph.keys());
         return this._updateMutex.runExclusive(async () => {
             // Promise.all(notebookCells.map(this.updateParagraph.bind(this)))
@@ -624,7 +628,7 @@ export class ZeppelinKernel
             {
                 await this._updateParagraph(cell);
             }
-            logDebug("updatePollingParagraphsDirect ends");
+            logger.debug("updatePollingParagraphsDirect ends");
         });
     }
 
@@ -649,12 +653,12 @@ export class ZeppelinKernel
         let config = vscode.workspace.getConfiguration('zeppelin');
         let throttleTime: number = config.get('autosave.throttleTime', 3);
 
-        logDebug("_doUpdatePollingParagraphs", this._mapUpdateParagraph);
+        logger.debug("_doUpdatePollingParagraphs", this._mapUpdateParagraph);
         for (let [cell, entry] of this._mapUpdateParagraph)
         {
             if (cell.metadata.resolvingDiff || cell.metadata.syncConflict !== undefined)
             {
-                logDebug("_doUpdatePollingParagraphs: cell has conflict or resolving diff, skipped", cell);
+                logger.warn("_doUpdatePollingParagraphs: cell has conflict or resolving diff, skipped", cell);
                 continue;
             }
             let requestTime = entry.requestTime;
@@ -662,7 +666,7 @@ export class ZeppelinKernel
                 && throttleTime * 1000 < Date.now() - requestTime) {
                 if (cell.index < 0)
                 {
-                    logDebug("_doUpdatePollingParagraphs: deleted cell", cell);
+                    logger.debug("_doUpdatePollingParagraphs: deleted cell", cell);
                 }
                 await this.updateParagraph(cell);
             }
@@ -914,12 +918,12 @@ export class ZeppelinKernel
         return await this._updateMutex.runExclusive(async () => {
 
         this._registerSyncNote(note);
-        logDebug("syncNote start");
+        logger.info("syncNote start");
 
         let serverNote = await this.getNoteInfo(note);
         if (serverNote === undefined)
         {
-            logDebug("syncNote failed");
+            logger.warn("syncNote failed");
             this._unregisterSyncNote(note);
             return;
         }
@@ -1054,7 +1058,7 @@ export class ZeppelinKernel
         });
 
         this._unregisterSyncNote(note);
-        logDebug("syncNote end");
+        logger.info("syncNote end");
     });
     }
 
@@ -1073,7 +1077,7 @@ export class ZeppelinKernel
         {
             return;
         }
-        logDebug(`remote cell revision accepted`, cell);
+        logger.info(`remote cell revision accepted`, cell);
 
         let serverCellData = parseParagraphToCellData(conflict);
         // Clear the conflict and resolving markers on the replacement cell
@@ -1100,7 +1104,7 @@ export class ZeppelinKernel
         {
             return;
         }
-        logDebug(`local cell revision accepted`, cell);
+        logger.info(`local cell revision accepted`, cell);
 
         // Clear conflict markers
         await this.editWithoutParagraphUpdate(async () =>
@@ -1118,7 +1122,7 @@ export class ZeppelinKernel
         }
         catch (err)
         {
-            logDebug("acceptLocalCell: error pushing local text to server", err);
+            logger.error("acceptLocalCell: error pushing local text to server", err);
             vscode.window.showErrorMessage(
                 `Failed to push local changes to server: ${err instanceof Error ? err.message : err}`
             );
@@ -1187,7 +1191,7 @@ export class ZeppelinKernel
         );
         if (res instanceof AxiosError)
         {
-            logDebug("error in updateParagraphText", res);
+            logger.error("error in updateParagraphText", res);
             await this.editWithoutParagraphUpdate(async () => {
                 await this.updateCellMetadata(cell, {"status": res.response?.status});
             })
@@ -1218,14 +1222,14 @@ export class ZeppelinKernel
         );
         if (res instanceof AxiosError)
         {
-            logDebug("error in updateParagraphConfig", res);
+            logger.error("error in updateParagraphConfig", res);
             await this.editWithoutParagraphUpdate(async () => {
                 await this.updateCellMetadata(cell, {"status": res.response?.status});
             });
             throw res;
         }
 
-        logDebug(`UpdateParagraphConfig: pollUpdateCellMetadata`);
+        logger.debug(`UpdateParagraphConfig: pollUpdateCellMetadata`);
         await this.pollUpdateCellMetadata(cell, res?.data.body);
     }
 
@@ -1235,7 +1239,7 @@ export class ZeppelinKernel
             // local changes until the user resolves the conflict.
             if (cell.metadata.syncConflict !== undefined)
             {
-                logDebug("updateParagraph: cell has sync conflict, skipped", cell);
+                logger.warn("updateParagraph: cell has sync conflict, skipped", cell);
                 this._unregisterParagraphUpdateDirect(cell);
                 return;
             }
@@ -1243,7 +1247,7 @@ export class ZeppelinKernel
             // index = -1: cell has been deleted from notebook
             if (cell.index === -1)
             {
-                logDebug(`updateParagraph: cell to be deleted`, cell);
+                logger.debug(`updateParagraph: cell to be deleted`, cell);
                 this.cellStatusBar?.untrackCell(cell);
                 this._service?.deleteParagraph(
                     cell.notebook.metadata.id, cell.metadata.id
@@ -1251,7 +1255,7 @@ export class ZeppelinKernel
 
                 this._mapUpdateParagraph.delete(cell);
 
-                logDebug(`updateParagraph: sync cell metadata`, cell);
+                logger.debug(`updateParagraph: sync cell metadata`, cell);
                 await this.updateNoteMetadata(
                     cell.notebook,
                     await this.getNoteInfo(cell.notebook) ?? {}
@@ -1262,9 +1266,9 @@ export class ZeppelinKernel
             // create corresponding paragraph when a cell is newly created
             if (cell.metadata.id === undefined)
             {
-                logDebug(`updateParagraph: cell to be created`, cell);
+                logger.debug(`updateParagraph: cell to be created`, cell);
                 await this.createParagraph(cell);
-                logDebug(`updateParagraph: sync cell metadata`, cell);
+                logger.debug(`updateParagraph: sync cell metadata`, cell);
                 await this.updateNoteMetadata(
                     cell.notebook,
                     await this.getNoteInfo(cell.notebook) ?? {}
@@ -1275,12 +1279,12 @@ export class ZeppelinKernel
                 cell.notebook.metadata.paragraphs.findIndex(
                     (paragraph: ParagraphData) => paragraph.id === cell.metadata.id))
             {
-                logDebug(`updateParagraph: cell position to be changed`, cell);
+                logger.debug(`updateParagraph: cell position to be changed`, cell);
                 // cell index has changed, update to server
                 await this.getService()?.moveParagraphToIndex(
                     cell.notebook.metadata.id, cell.metadata.id, cell.index
                 );
-                logDebug(`updateParagraph: sync cell metadata`, cell);
+                logger.debug(`updateParagraph: sync cell metadata`, cell);
                 await this.updateNoteMetadata(
                     cell.notebook,
                     await this.getNoteInfo(cell.notebook) ?? {}
@@ -1316,7 +1320,7 @@ export class ZeppelinKernel
                     {
                         // Server changed independently — flag conflict
                         // instead of pushing.
-                        logDebug("updateParagraph: server changed independently, flagging sync conflict");
+                        logger.warn("updateParagraph: server changed independently, flagging sync conflict");
                         await this.editWithoutParagraphUpdate(async () => {
                             await this.updateCellMetadata(cell, {
                                 syncConflict: serverParagraph
@@ -1328,9 +1332,9 @@ export class ZeppelinKernel
                     }
                 }
 
-                logDebug("updateParagraph: updateParagraphConfig");
+                logger.debug("updateParagraph: updateParagraphConfig");
                 let res = await this.updateParagraphConfig(cell);
-                logDebug("updateParagraph: updateParagraphText");
+                logger.debug("updateParagraph: updateParagraphText");
                 res = await this.updateParagraphText(cell);
             }
 
@@ -1343,7 +1347,7 @@ export class ZeppelinKernel
             }
         } catch (err)
         {
-            logDebug("error in _updateParagraph", err);
+            logger.error("error in _updateParagraph", err);
             if (cell.metadata.id === undefined)
             {
                 // retry creating cell
@@ -1396,7 +1400,7 @@ export class ZeppelinKernel
         let interpreterMap = this._mapInterpreterCache;
         if (interpreterMap === undefined)
         {
-            logDebug("autoDetectCellLanguage: interpreter cache not available, skipping");
+            logger.warn("autoDetectCellLanguage: interpreter cache not available, skipping");
             return;
         }
 
@@ -1413,7 +1417,7 @@ export class ZeppelinKernel
 
         if (vscLang === undefined)
         {
-            logDebug(`autoDetectCellLanguage: unknown interpreter '${fullInterpreterId}'`);
+            logger.warn(`autoDetectCellLanguage: unknown interpreter '${fullInterpreterId}'`);
             return;
         }
 
@@ -1454,11 +1458,11 @@ export class ZeppelinKernel
                 });
             });
 
-            logDebug(`autoDetectCellLanguage: set language to '${vscLang}'`);
+            logger.debug(`autoDetectCellLanguage: set language to '${vscLang}'`);
         }
         catch (err)
         {
-            logDebug('_applyCellLanguage error', err);
+            logger.error('_applyCellLanguage error', err);
             vscode.window.showWarningMessage(
                 `Unable to auto-detect cell language '${vscLang}'. `
                 + `Please select it manually.`

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -37,8 +37,13 @@ export class ZeppelinKernel
     private _service?: NotebookService;
     private readonly _controller: vscode.NotebookController;
     private _isActive = false;
-    public updateMutex = new Mutex("updateMutex");
-    public editMutex = new Mutex("editMutex");
+    private _updateMutex = new Mutex("updateMutex");
+    private _editMutex = new Mutex("editMutex");
+
+    /** Whether the edit mutex is currently held. */
+    public isEditLocked(): boolean { return this._editMutex.isLocked(); }
+    /** Whether the update mutex is currently held. */
+    public isUpdateLocked(): boolean { return this._updateMutex.isLocked(); }
 
     // private _timerSyncNote?: ReturnType<typeof setInterval>;
     private _timerUpdateCell?: ReturnType<typeof setTimeout>;
@@ -557,11 +562,11 @@ export class ZeppelinKernel
 
         logDebug("registerParagraphUpdate", cell);
 
-        return this.updateMutex.runExclusive(async () =>
+        return this._updateMutex.runExclusive(async () =>
         {
             // Flush any deferred metadata updates inside the mutex so
             // cell.metadata.text is current and the snapshot is atomic
-            // with respect to other updateMutex holders.
+            // with respect to other _updateMutex holders.
             await this.applyPolledNotebookEdits();
 
             if (!this._mapUpdateParagraph.has(cell))
@@ -594,7 +599,7 @@ export class ZeppelinKernel
     public async unregisterParagraphUpdate(cell: vscode.NotebookCell)
     {
         logDebug("unregisterParagraphUpdate", cell);
-        return this.updateMutex.runExclusive(async () =>
+        return this._updateMutex.runExclusive(async () =>
         {
             return this._mapUpdateParagraph.delete(cell);
         });
@@ -613,7 +618,7 @@ export class ZeppelinKernel
     public async updatePollingParagraphsDirect() {
         logDebug("updatePollingParagraphsDirect", this._mapUpdateParagraph);
         // let notebookCells = Array.from(this._mapUpdateParagraph.keys());
-        return this.updateMutex.runExclusive(async () => {
+        return this._updateMutex.runExclusive(async () => {
             // Promise.all(notebookCells.map(this.updateParagraph.bind(this)))
             for (let cell of this._mapUpdateParagraph.keys())
             {
@@ -625,7 +630,7 @@ export class ZeppelinKernel
 
     public async editWithoutParagraphUpdate(func: () => Promise<void>)
     {
-        return this.editMutex.runExclusive(async () =>
+        return this._editMutex.runExclusive(async () =>
         {
             this._editWithoutParagraphUpdateDepth++;
             try
@@ -906,7 +911,7 @@ export class ZeppelinKernel
             return;
         }
 
-        return await this.updateMutex.runExclusive(async () => {
+        return await this._updateMutex.runExclusive(async () => {
 
         this._registerSyncNote(note);
         logDebug("syncNote start");
@@ -1365,7 +1370,7 @@ export class ZeppelinKernel
 
     public async updateParagraph(cell: vscode.NotebookCell)
     {
-        return this.updateMutex.runExclusive(
+        return this._updateMutex.runExclusive(
             async () => 
             {
                 return await this._updateParagraph(cell);

--- a/src/extension/notebookSerializer.ts
+++ b/src/extension/notebookSerializer.ts
@@ -18,7 +18,7 @@ export class ZeppelinSerializer implements vscode.NotebookSerializer {
 		let raw: NoteData;
 
 		var contents = new TextDecoder().decode(content);
-		let reEmpty = new RegExp('^[\s\n\t\r]*$');
+		let reEmpty = /^\s*$/;
 		if (reEmpty.test(contents)) {
 			logDebug(contents);
 			raw = {};

--- a/src/extension/notebookSerializer.ts
+++ b/src/extension/notebookSerializer.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { logDebug } from '../common/common';
+import { logger } from '../common/logger';
 import {
 	parseParagraphToCellData,
 	parseCellToParagraphData
@@ -20,14 +20,14 @@ export class ZeppelinSerializer implements vscode.NotebookSerializer {
 		var contents = new TextDecoder().decode(content);
 		let reEmpty = /^\s*$/;
 		if (reEmpty.test(contents)) {
-			logDebug(contents);
+			logger.debug(contents);
 			raw = {};
 		}
 		else {
 			try {
 				raw = <NoteData>JSON.parse(contents);
 			} catch(err) {
-				logDebug("error serializing note file to JSON", err);
+				logger.error("error serializing note file to JSON", err);
 				throw err;
 			}
 		}
@@ -36,6 +36,7 @@ export class ZeppelinSerializer implements vscode.NotebookSerializer {
 		const cells = raw.paragraphs
 						? raw.paragraphs.map(parseParagraphToCellData)
 						: [];
+		logger.info(`deserializeNotebook: loaded ${cells.length} cells from note '${raw.name ?? '(unnamed)'}'`);
 
 		let note = new vscode.NotebookData(cells);
 		note.metadata = raw;

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -153,6 +153,72 @@ export class Uri {
     }
 }
 
+// ── WorkspaceEdit / NotebookEdit / NotebookRange ──────────────────────────────
+
+export class WorkspaceEdit {
+    private _edits = new Map<string, unknown[]>();
+
+    set(uri: Uri, edits: unknown[]): void {
+        this._edits.set(uri.toString(), edits);
+    }
+
+    get(uri: Uri): unknown[] {
+        return this._edits.get(uri.toString()) ?? [];
+    }
+}
+
+export class NotebookRange {
+    readonly start: number;
+    readonly end: number;
+    readonly isEmpty: boolean;
+
+    constructor(start: number, end: number) {
+        this.start = start;
+        this.end = end;
+        this.isEmpty = start === end;
+    }
+}
+
+export class NotebookEdit {
+    static replaceCells(range: NotebookRange, cells: NotebookCellData[]): NotebookEdit {
+        return new NotebookEdit('replaceCells', { range, cells });
+    }
+    static insertCells(index: number, cells: NotebookCellData[]): NotebookEdit {
+        return new NotebookEdit('insertCells', { index, cells });
+    }
+    static deleteCells(range: NotebookRange): NotebookEdit {
+        return new NotebookEdit('deleteCells', { range });
+    }
+    static updateNotebookMetadata(metadata: Record<string, unknown>): NotebookEdit {
+        return new NotebookEdit('updateNotebookMetadata', { metadata });
+    }
+    static updateCellMetadata(index: number, metadata: Record<string, unknown>): NotebookEdit {
+        return new NotebookEdit('updateCellMetadata', { index, metadata });
+    }
+
+    readonly type: string;
+    readonly data: unknown;
+    private constructor(type: string, data: unknown) {
+        this.type = type;
+        this.data = data;
+    }
+}
+
+export class ThemeIcon {
+    readonly id: string;
+    constructor(id: string) { this.id = id; }
+}
+
+// ── Languages namespace ───────────────────────────────────────────────────────
+
+export const languages = {
+    setTextDocumentLanguage: async (_document: unknown, _languageId: string) => {},
+};
+
+// ── Misc globals ──────────────────────────────────────────────────────────────
+
+export const version = '1.90.0';
+
 // ── Workspace / Window namespaces ─────────────────────────────────────────────
 
 function createWorkspaceConfiguration(defaults: Record<string, unknown> = {}) {

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -273,6 +273,14 @@ export const window = {
         Promise.resolve(undefined as string | undefined),
     showErrorMessage: (_message: string, ..._args: unknown[]) =>
         Promise.resolve(undefined as string | undefined),
+    createOutputChannel: (_name: string) => ({
+        appendLine: (_value: string) => {},
+        append: (_value: string) => {},
+        clear: () => {},
+        show: () => {},
+        hide: () => {},
+        dispose: () => {},
+    }),
     activeNotebookEditor: undefined as unknown,
 };
 

--- a/src/test/suite/cellStatusBar.test.ts
+++ b/src/test/suite/cellStatusBar.test.ts
@@ -28,12 +28,6 @@ describe('CellStatusProvider Test Suite', () => {
             assert.deepStrictEqual(items, []);
         });
 
-        it('returns empty array for Markup cells', () => {
-            const cell = createMockCell({ kind: vscode.NotebookCellKind.Markup });
-            const items = provider.provideCellStatusBarItems(cell as any);
-            assert.deepStrictEqual(items, []);
-        });
-
         it('shows sync conflict indicator when syncConflict is set', async () => {
             const cell = createMockCell({
                 status: 'READY',

--- a/src/test/suite/mocks.ts
+++ b/src/test/suite/mocks.ts
@@ -159,7 +159,7 @@ export function createMockCell(opts: MockCellOptions = {}): MockNotebookCell {
             getText: () => opts.text ?? '%python\nprint("hello")\n',
             isClosed: opts.isClosed ?? false,
             languageId: opts.languageId ?? 'python',
-            uri: vscode.Uri.parse('untitled:cell_1'),
+            uri: vscode.Uri.parse('vscode-notebook-cell:/tmp/test-note.zpln'),
         },
         notebook: {
             isClosed: opts.notebookClosed ?? false,
@@ -192,9 +192,11 @@ export interface MockKernel {
     updatePollingParagraphsDirect: () => Promise<void>;
     editWithoutParagraphUpdate: (fn: () => Promise<void>) => Promise<void>;
     updateCellMetadata: (cell: any, metadata: any) => Promise<boolean>;
+    removeCellMetadata: (cell: any, keys: string[]) => Promise<boolean>;
     applyPolledNotebookEdits: () => Promise<void>;
     isNoteSyncing: (note: any) => boolean;
     hasPendingParagraphUpdate: (cell: any) => boolean;
+    editMutex: { isLocked: () => boolean };
 
     // internal controller
     _controller: MockNotebookController;
@@ -247,9 +249,11 @@ export function createMockKernel(opts: MockKernelOptions = {}): MockKernel {
         updatePollingParagraphsDirect: async () => {},
         editWithoutParagraphUpdate: async (fn: () => Promise<void>) => { await fn(); },
         updateCellMetadata: async (_cell: any, _metadata: any) => true,
+        removeCellMetadata: async (_cell: any, _keys: string[]) => true,
         applyPolledNotebookEdits: async () => {},
         isNoteSyncing: (_note: any) => false,
         hasPendingParagraphUpdate: (_cell: any) => false,
+        editMutex: { isLocked: () => false },
     };
 
     return kernel;

--- a/src/test/suite/mocks.ts
+++ b/src/test/suite/mocks.ts
@@ -196,7 +196,8 @@ export interface MockKernel {
     applyPolledNotebookEdits: () => Promise<void>;
     isNoteSyncing: (note: any) => boolean;
     hasPendingParagraphUpdate: (cell: any) => boolean;
-    editMutex: { isLocked: () => boolean };
+    isEditLocked: () => boolean;
+    isUpdateLocked: () => boolean;
 
     // internal controller
     _controller: MockNotebookController;
@@ -253,7 +254,8 @@ export function createMockKernel(opts: MockKernelOptions = {}): MockKernel {
         applyPolledNotebookEdits: async () => {},
         isNoteSyncing: (_note: any) => false,
         hasPendingParagraphUpdate: (_cell: any) => false,
-        editMutex: { isLocked: () => false },
+        isEditLocked: () => false,
+        isUpdateLocked: () => false,
     };
 
     return kernel;

--- a/src/test/suite/notebookKernel.test.ts
+++ b/src/test/suite/notebookKernel.test.ts
@@ -718,12 +718,12 @@ describe('ZeppelinKernel Test Suite', () => {
 
         it('updateMutex is not locked initially', () => {
             kernel = new ZeppelinKernel(context);
-            assert.strictEqual(kernel.updateMutex.isLocked(), false);
+            assert.strictEqual(kernel.isUpdateLocked(), false);
         });
 
         it('editMutex is not locked initially', () => {
             kernel = new ZeppelinKernel(context);
-            assert.strictEqual(kernel.editMutex.isLocked(), false);
+            assert.strictEqual(kernel.isEditLocked(), false);
         });
     });
 

--- a/src/test/suite/notebookKernel.test.ts
+++ b/src/test/suite/notebookKernel.test.ts
@@ -1,0 +1,895 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { vi } from 'vitest';
+import { ZeppelinKernel } from '../../extension/notebookKernel';
+import { createMockCell, createMockKernel } from './mocks';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Minimal mock ExtensionContext for constructing a ZeppelinKernel. */
+function createMockContext(): any {
+    const wsState = new Map<string, any>();
+    const globalState = new Map<string, any>();
+    const secrets = new Map<string, string>();
+
+    return {
+        extension: { packageJSON: { version: '0.0.0-test' } },
+        subscriptions: [],
+        workspaceState: {
+            get: (key: string, defaultValue?: any) => wsState.has(key) ? wsState.get(key) : defaultValue,
+            update: (key: string, value: any) => { wsState.set(key, value); return Promise.resolve(); },
+        },
+        globalState: {
+            get: (key: string, defaultValue?: any) => globalState.has(key) ? globalState.get(key) : defaultValue,
+            update: (key: string, value: any) => { globalState.set(key, value); return Promise.resolve(); },
+            setKeysForSync: () => {},
+        },
+        secrets: {
+            get: async (key: string) => secrets.get(key),
+            store: async (key: string, value: string) => { secrets.set(key, value); },
+            delete: async (key: string) => { secrets.delete(key); },
+        },
+    };
+}
+
+/** Minimal mock NotebookService that stubs all API calls. */
+function createMockService(overrides: Record<string, any> = {}): any {
+    return {
+        baseURL: 'http://localhost:8080',
+        listNotes: async () => ({ data: { body: [] } }),
+        getInfo: async (_noteId: string) => ({ data: { body: { paragraphs: [] } } }),
+        createNote: async () => ({ data: { body: 'note_new' } }),
+        importNote: async () => ({ data: { body: 'note_imported' } }),
+        getParagraphInfo: async (_noteId: string, _paraId: string) => ({
+            data: { body: { id: 'para_001', status: 'READY', text: '%python\nprint("hello")\n' } },
+        }),
+        runParagraph: async () => ({ data: { body: { code: 'SUCCESS', msg: [] } } }),
+        stopParagraph: async () => ({ status: 200 }),
+        createParagraph: async () => ({ data: { body: 'para_new' } }),
+        updateParagraphText: async () => ({ data: { body: {} } }),
+        updateParagraphConfig: async () => ({ data: { body: {} } }),
+        moveParagraphToIndex: async () => ({}),
+        deleteParagraph: async () => ({}),
+        listInterpreters: async () => ({ data: { body: [] } }),
+        getInterpreterSetting: async () => ({ data: { status: 'OK', body: { status: 'READY' } } }),
+        restartInterpreter: async () => ({ status: 200 }),
+        stopAll: async () => ({ data: {} }),
+        setHttpsAgent: () => {},
+        cancelConnect: () => {},
+        resetCancelToken: () => {},
+        onSessionExpired: undefined as (() => void) | undefined,
+        ...overrides,
+    };
+}
+
+// ── Test Suite ───────────────────────────────────────────────────────────────
+
+describe('ZeppelinKernel Test Suite', () => {
+
+    let context: any;
+    let kernel: ZeppelinKernel;
+
+    beforeEach(() => {
+        context = createMockContext();
+    });
+
+    afterEach(() => {
+        try { kernel?.dispose(); } catch { /* ignore */ }
+    });
+
+    // ── Constructor & Lifecycle ──────────────────────────────────────────
+
+    describe('constructor & lifecycle', () => {
+
+        it('constructs without service and is inactive', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.isActive(), false);
+        });
+
+        it('constructs with service having baseURL and activates', () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            assert.strictEqual(kernel.isActive(), true);
+        });
+
+        it('has correct readonly properties', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.id, 'zeppelin-notebook-kernel');
+            assert.strictEqual(kernel.notebookType, 'zeppelin-notebook');
+            assert.strictEqual(kernel.label, 'Zeppelin Notebook');
+            assert.ok(Array.isArray(kernel.supportedLanguages));
+            assert.ok(kernel.supportedLanguages.includes('python'));
+        });
+
+        it('getContext returns the extension context', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.getContext(), context);
+        });
+
+        it('getController returns a controller object', () => {
+            kernel = new ZeppelinKernel(context);
+            const ctrl = kernel.getController();
+            assert.ok(ctrl);
+            assert.ok(typeof ctrl.dispose === 'function');
+        });
+
+        it('dispose deactivates and disposes controller', () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            assert.strictEqual(kernel.isActive(), true);
+            kernel.dispose();
+            assert.strictEqual(kernel.isActive(), false);
+        });
+    });
+
+    // ── activate / deactivate ───────────────────────────────────────────
+
+    describe('activate / deactivate', () => {
+
+        it('activate without service returns false', () => {
+            kernel = new ZeppelinKernel(context);
+            const result = kernel.activate();
+            assert.strictEqual(result, false);
+        });
+
+        it('deactivate when already inactive returns false', () => {
+            kernel = new ZeppelinKernel(context);
+            const result = kernel.deactivate();
+            assert.strictEqual(result, false);
+        });
+
+        it('deactivate after activation returns false (isActive)', () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            assert.strictEqual(kernel.isActive(), true);
+            const result = kernel.deactivate();
+            // deactivate returns the isActive value after deactivation
+            assert.strictEqual(result, false);
+            assert.strictEqual(kernel.isActive(), false);
+        });
+    });
+
+    // ── setDisplay ──────────────────────────────────────────────────────
+
+    describe('setDisplay', () => {
+
+        it('updates controller label, description, and detail', () => {
+            kernel = new ZeppelinKernel(context);
+            kernel.setDisplay('My Label', 'My Desc', 'My Detail');
+            const ctrl = kernel.getController();
+            assert.strictEqual(ctrl.label, 'My Label');
+            assert.strictEqual(ctrl.description, 'My Desc');
+            assert.strictEqual(ctrl.detail, 'My Detail');
+        });
+
+        it('handles undefined optional params', () => {
+            kernel = new ZeppelinKernel(context);
+            kernel.setDisplay('Label');
+            const ctrl = kernel.getController();
+            assert.strictEqual(ctrl.label, 'Label');
+            assert.strictEqual(ctrl.description, undefined);
+            assert.strictEqual(ctrl.detail, undefined);
+        });
+    });
+
+    // ── getService / setService ─────────────────────────────────────────
+
+    describe('getService / setService', () => {
+
+        it('getService returns undefined when no service is set', () => {
+            kernel = new ZeppelinKernel(context);
+            // No service provided, but constructor may assign service
+            // The kernel was constructed without service
+            assert.strictEqual(kernel.getService(), undefined);
+        });
+
+        it('getService returns service when provided in constructor', () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            assert.strictEqual(kernel.getService(), service);
+        });
+    });
+
+    // ── isNoteSyncing ───────────────────────────────────────────────────
+
+    describe('isNoteSyncing', () => {
+
+        it('returns false for undefined notebook', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.isNoteSyncing(undefined), false);
+        });
+
+        it('returns false for non-syncing notebook', () => {
+            kernel = new ZeppelinKernel(context);
+            const fakeNote = { uri: vscode.Uri.parse('file:///test.zpln'), metadata: { id: 'n1' } };
+            assert.strictEqual(kernel.isNoteSyncing(fakeNote as any), false);
+        });
+    });
+
+    // ── hasPendingParagraphUpdate ────────────────────────────────────────
+
+    describe('hasPendingParagraphUpdate', () => {
+
+        it('returns false for cell with no pending update', () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({ status: 'READY' });
+            assert.strictEqual(kernel.hasPendingParagraphUpdate(cell as any), false);
+        });
+    });
+
+    // ── updateCellMetadata ──────────────────────────────────────────────
+
+    describe('updateCellMetadata', () => {
+
+        it('calls workspace.applyEdit and returns result', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({ status: 'READY' });
+            const result = await kernel.updateCellMetadata(cell as any, { status: 'RUNNING' });
+            assert.strictEqual(result, true);
+        });
+    });
+
+    // ── removeCellMetadata ──────────────────────────────────────────────
+
+    describe('removeCellMetadata', () => {
+
+        it('calls workspace.applyEdit and returns result', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({
+                status: 'READY',
+                syncConflict: { text: 'remote' },
+            });
+            const result = await kernel.removeCellMetadata(
+                cell as any, ['syncConflict']
+            );
+            assert.strictEqual(result, true);
+        });
+    });
+
+    // ── editWithoutParagraphUpdate ──────────────────────────────────────
+
+    describe('editWithoutParagraphUpdate', () => {
+
+        it('executes the callback and returns its result', async () => {
+            kernel = new ZeppelinKernel(context);
+            let called = false;
+            await kernel.editWithoutParagraphUpdate(async () => {
+                called = true;
+            });
+            assert.strictEqual(called, true);
+        });
+
+        it('runs callback exclusively via editMutex', async () => {
+            kernel = new ZeppelinKernel(context);
+            const order: number[] = [];
+            const p1 = kernel.editWithoutParagraphUpdate(async () => {
+                order.push(1);
+            });
+            const p2 = kernel.editWithoutParagraphUpdate(async () => {
+                order.push(2);
+            });
+            await Promise.all([p1, p2]);
+            assert.deepStrictEqual(order, [1, 2]);
+        });
+    });
+
+    // ── pollUpdateCellMetadata / applyPolledNotebookEdits ────────────────
+
+    describe('pollUpdateCellMetadata & applyPolledNotebookEdits', () => {
+
+        it('queues and then flushes a metadata edit', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({ status: 'READY' });
+
+            await kernel.pollUpdateCellMetadata(cell as any, { status: 'RUNNING' });
+            // The edit is queued but not yet applied
+            // applyPolledNotebookEdits should flush it
+            await kernel.applyPolledNotebookEdits();
+            // No error means success
+        });
+
+        it('skips edits for deleted cells (index === -1)', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({ status: 'READY', index: -1 });
+
+            await kernel.pollUpdateCellMetadata(cell as any, { status: 'RUNNING' });
+            await kernel.applyPolledNotebookEdits();
+            // Should not throw
+        });
+
+        it('skips edits for cells with syncConflict', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({
+                status: 'READY',
+                syncConflict: { text: 'remote text' },
+            });
+
+            await kernel.pollUpdateCellMetadata(cell as any, { status: 'RUNNING' });
+            await kernel.applyPolledNotebookEdits();
+            // Should skip without error
+        });
+    });
+
+    // ── registerParagraphUpdate / unregisterParagraphUpdate ──────────────
+
+    describe('registerParagraphUpdate / unregisterParagraphUpdate', () => {
+
+        it('registers a cell for paragraph update', async () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+
+            await kernel.registerParagraphUpdate(cell as any);
+            assert.strictEqual(kernel.hasPendingParagraphUpdate(cell as any), true);
+        });
+
+        it('does not register if resolvingDiff is set', async () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+            (cell.metadata as any).resolvingDiff = true;
+
+            await kernel.registerParagraphUpdate(cell as any);
+            assert.strictEqual(kernel.hasPendingParagraphUpdate(cell as any), false);
+        });
+
+        it('unregisters a cell from paragraph update', async () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+
+            await kernel.registerParagraphUpdate(cell as any);
+            assert.strictEqual(kernel.hasPendingParagraphUpdate(cell as any), true);
+
+            await kernel.unregisterParagraphUpdate(cell as any);
+            assert.strictEqual(kernel.hasPendingParagraphUpdate(cell as any), false);
+        });
+
+        it('does not double-register the same cell', async () => {
+            const service = createMockService();
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+
+            await kernel.registerParagraphUpdate(cell as any);
+            await kernel.registerParagraphUpdate(cell as any);
+            assert.strictEqual(kernel.hasPendingParagraphUpdate(cell as any), true);
+
+            await kernel.unregisterParagraphUpdate(cell as any);
+            assert.strictEqual(kernel.hasPendingParagraphUpdate(cell as any), false);
+        });
+    });
+
+    // ── listNotes / hasNote / doesNotebookExist ─────────────────────────
+
+    describe('listNotes / hasNote / doesNotebookExist', () => {
+
+        it('listNotes returns empty array when no service', async () => {
+            kernel = new ZeppelinKernel(context);
+            const notes = await kernel.listNotes();
+            assert.deepStrictEqual(notes, []);
+        });
+
+        it('listNotes returns body from service', async () => {
+            const service = createMockService({
+                listNotes: async () => ({
+                    data: { body: [{ id: 'n1', path: '/test' }] },
+                }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const notes = await kernel.listNotes();
+            assert.strictEqual(notes.length, 1);
+            assert.strictEqual(notes[0].id, 'n1');
+        });
+
+        it('hasNote returns false for undefined noteId', async () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(await kernel.hasNote(undefined), false);
+        });
+
+        it('hasNote returns true when note exists', async () => {
+            const service = createMockService({
+                listNotes: async () => ({
+                    data: { body: [{ id: 'n1', path: '/myNote' }] },
+                }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            assert.strictEqual(await kernel.hasNote('n1'), true);
+        });
+
+        it('hasNote returns false when note is in Trash', async () => {
+            const service = createMockService({
+                listNotes: async () => ({
+                    data: { body: [{ id: 'n1', path: '/~Trash/myNote' }] },
+                }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            assert.strictEqual(await kernel.hasNote('n1'), false);
+        });
+
+        it('hasNote returns false when note does not exist', async () => {
+            const service = createMockService({
+                listNotes: async () => ({
+                    data: { body: [{ id: 'n1', path: '/myNote' }] },
+                }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            assert.strictEqual(await kernel.hasNote('n2'), false);
+        });
+
+        it('doesNotebookExist returns false when inactive', async () => {
+            kernel = new ZeppelinKernel(context);
+            const note = { metadata: { id: 'n1' } };
+            assert.strictEqual(await kernel.doesNotebookExist(note as any), false);
+        });
+
+        it('doesNotebookExist returns true when active and note exists', async () => {
+            const service = createMockService({
+                listNotes: async () => ({
+                    data: { body: [{ id: 'n1', path: '/myNote' }] },
+                }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const note = { metadata: { id: 'n1' } };
+            assert.strictEqual(await kernel.doesNotebookExist(note as any), true);
+        });
+    });
+
+    // ── stopParagraph ───────────────────────────────────────────────────
+
+    describe('stopParagraph', () => {
+
+        it('returns true when service responds with 200', async () => {
+            const service = createMockService({
+                stopParagraph: async () => ({ status: 200 }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'RUNNING' });
+            const result = await kernel.stopParagraph(cell as any);
+            assert.strictEqual(result, true);
+        });
+
+        it('returns false when service responds with non-200', async () => {
+            const service = createMockService({
+                stopParagraph: async () => ({ status: 500 }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'RUNNING' });
+            const result = await kernel.stopParagraph(cell as any);
+            assert.strictEqual(result, false);
+        });
+    });
+
+    // ── getExecutionByParagraphId ───────────────────────────────────────
+
+    describe('getExecutionByParagraphId', () => {
+
+        it('returns undefined when no execution is tracked', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.getExecutionByParagraphId('para_001'), undefined);
+        });
+    });
+
+    // ── acceptRemoteCell ────────────────────────────────────────────────
+
+    describe('acceptRemoteCell', () => {
+
+        it('does nothing when cell has no syncConflict', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({ status: 'READY' });
+            // Should not throw
+            await kernel.acceptRemoteCell(cell as any);
+        });
+
+        it('replaces cells when syncConflict is present', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({
+                status: 'READY',
+                syncConflict: {
+                    id: 'para_001',
+                    status: 'READY',
+                    text: '%python\nremote_code()\n',
+                    config: { editorSetting: { language: 'python' } },
+                },
+            });
+            // Should not throw — calls editWithoutParagraphUpdate → replaceNoteCells
+            await kernel.acceptRemoteCell(cell as any);
+        });
+    });
+
+    // ── acceptLocalCell ─────────────────────────────────────────────────
+
+    describe('acceptLocalCell', () => {
+
+        it('does nothing when cell has no syncConflict', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({ status: 'READY' });
+            await kernel.acceptLocalCell(cell as any);
+        });
+
+        it('clears conflict and pushes text when syncConflict exists', async () => {
+            let textPushed = false;
+            const service = createMockService({
+                updateParagraphText: async () => {
+                    textPushed = true;
+                    return { data: { body: {} } };
+                },
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({
+                status: 'READY',
+                syncConflict: { text: 'remote text' },
+            });
+            await kernel.acceptLocalCell(cell as any);
+            assert.strictEqual(textPushed, true);
+        });
+
+        it('shows error message when pushing text fails', async () => {
+            let errorShown = false;
+            const origShowError = vscode.window.showErrorMessage;
+            (vscode.window as any).showErrorMessage = (..._args: any[]) => {
+                errorShown = true;
+                return Promise.resolve(undefined);
+            };
+
+            const service = createMockService({
+                updateParagraphText: async () => { throw new Error('Network fail'); },
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({
+                status: 'READY',
+                syncConflict: { text: 'remote text' },
+            });
+            await kernel.acceptLocalCell(cell as any);
+            assert.strictEqual(errorShown, true);
+
+            (vscode.window as any).showErrorMessage = origShowError;
+        });
+    });
+
+    // ── updatePollingParagraphsDirect ────────────────────────────────────
+
+    describe('updatePollingParagraphsDirect', () => {
+
+        it('completes without error when no pending updates', async () => {
+            kernel = new ZeppelinKernel(context);
+            await kernel.updatePollingParagraphsDirect();
+        });
+    });
+
+    // ── updateNoteMetadata ──────────────────────────────────────────────
+
+    describe('updateNoteMetadata', () => {
+
+        it('applies workspace edit', async () => {
+            kernel = new ZeppelinKernel(context);
+            const fakeNote = {
+                metadata: { id: 'n1', name: 'test' },
+                uri: vscode.Uri.parse('file:///tmp/test.zpln'),
+            };
+            const result = await kernel.updateNoteMetadata(
+                fakeNote as any, { name: 'updated' }
+            );
+            assert.strictEqual(result, true);
+        });
+    });
+
+    // ── replaceNoteCells / insertNoteCells / deleteNoteCells ─────────────
+
+    describe('notebook cell editing', () => {
+
+        let fakeNote: any;
+
+        beforeEach(() => {
+            kernel = new ZeppelinKernel(context);
+            fakeNote = {
+                metadata: { id: 'n1' },
+                uri: vscode.Uri.parse('file:///tmp/test.zpln'),
+            };
+        });
+
+        it('replaceNoteCells applies edit', async () => {
+            const range = new vscode.NotebookRange(0, 1);
+            const cellData = new vscode.NotebookCellData(
+                vscode.NotebookCellKind.Code, 'code', 'python'
+            );
+            const result = await kernel.replaceNoteCells(fakeNote, range, [cellData]);
+            assert.strictEqual(result, true);
+        });
+
+        it('insertNoteCells applies edit', async () => {
+            const cellData = new vscode.NotebookCellData(
+                vscode.NotebookCellKind.Code, 'code', 'python'
+            );
+            const result = await kernel.insertNoteCells(fakeNote, 0, [cellData]);
+            assert.strictEqual(result, true);
+        });
+
+        it('deleteNoteCells applies edit', async () => {
+            const range = new vscode.NotebookRange(0, 1);
+            const result = await kernel.deleteNoteCells(fakeNote, range);
+            assert.strictEqual(result, true);
+        });
+    });
+
+    // ── editNote ────────────────────────────────────────────────────────
+
+    describe('editNote', () => {
+
+        it('applies multiple edit types at once', async () => {
+            kernel = new ZeppelinKernel(context);
+            const fakeNote = {
+                metadata: { id: 'n1' },
+                uri: vscode.Uri.parse('file:///tmp/test.zpln'),
+            };
+            const range = new vscode.NotebookRange(0, 1);
+            const cellData = new vscode.NotebookCellData(
+                vscode.NotebookCellKind.Code, 'code', 'python'
+            );
+            const result = await kernel.editNote(
+                fakeNote as any,
+                range, [cellData],   // replace
+                0, [cellData],       // insert
+                range,               // delete
+                { name: 'updated' }  // metadata
+            );
+            assert.strictEqual(result, true);
+        });
+
+        it('handles no operations gracefully', async () => {
+            kernel = new ZeppelinKernel(context);
+            const fakeNote = {
+                metadata: { id: 'n1' },
+                uri: vscode.Uri.parse('file:///tmp/test.zpln'),
+            };
+            const result = await kernel.editNote(fakeNote as any);
+            assert.strictEqual(result, true);
+        });
+    });
+
+    // ── runParagraph ────────────────────────────────────────────────────
+
+    describe('runParagraph', () => {
+
+        it('returns cell output for sync execution', async () => {
+            const service = createMockService({
+                runParagraph: async () => ({
+                    data: {
+                        body: {
+                            code: 'SUCCESS',
+                            msg: [{ type: 'TEXT', data: 'hello world' }],
+                        },
+                    },
+                }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+            const result = await kernel.runParagraph(cell as any, true);
+            assert.ok(Array.isArray(result));
+            assert.ok(result.length > 0);
+        });
+
+        it('returns empty array when sync result has no body', async () => {
+            const service = createMockService({
+                runParagraph: async () => ({ data: {} }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+            const result = await kernel.runParagraph(cell as any, true);
+            assert.deepStrictEqual(result, []);
+        });
+
+        it('returns data for async execution', async () => {
+            const service = createMockService({
+                runParagraph: async () => ({ data: { status: 'OK' } }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+            const result = await kernel.runParagraph(cell as any, false);
+            assert.deepStrictEqual(result, { status: 'OK' });
+        });
+    });
+
+    // ── createNote / importNote ─────────────────────────────────────────
+
+    describe('createNote / importNote', () => {
+
+        it('createNote returns note id from service', async () => {
+            const service = createMockService({
+                createNote: async () => ({ data: { body: 'note_123' } }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const result = await kernel.createNote('TestNote');
+            assert.strictEqual(result, 'note_123');
+        });
+
+        it('importNote returns note id from service', async () => {
+            const service = createMockService({
+                importNote: async () => ({ data: { body: 'note_456' } }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const result = await kernel.importNote({ id: 'n1' });
+            assert.strictEqual(result, 'note_456');
+        });
+    });
+
+    // ── Mutex properties ────────────────────────────────────────────────
+
+    describe('mutex properties', () => {
+
+        it('updateMutex is not locked initially', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.updateMutex.isLocked(), false);
+        });
+
+        it('editMutex is not locked initially', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.editMutex.isLocked(), false);
+        });
+    });
+
+    // ── cellStatusBar ───────────────────────────────────────────────────
+
+    describe('cellStatusBar', () => {
+
+        it('cellStatusBar is undefined initially', () => {
+            kernel = new ZeppelinKernel(context);
+            assert.strictEqual(kernel.cellStatusBar, undefined);
+        });
+
+        it('cellStatusBar can be set', () => {
+            kernel = new ZeppelinKernel(context);
+            const fakeStatusBar = { scheduleTracking: () => {}, dispose: () => {} };
+            kernel.cellStatusBar = fakeStatusBar as any;
+            assert.strictEqual(kernel.cellStatusBar, fakeStatusBar);
+        });
+    });
+
+    // ── syncNote ────────────────────────────────────────────────────────
+
+    describe('syncNote', () => {
+
+        it('shows warning when note has no id', async () => {
+            let warningShown = false;
+            const origShowWarning = vscode.window.showWarningMessage;
+            (vscode.window as any).showWarningMessage = (..._args: any[]) => {
+                warningShown = true;
+                return Promise.resolve(undefined);
+            };
+
+            kernel = new ZeppelinKernel(context);
+            const fakeNote = {
+                metadata: {},
+                uri: vscode.Uri.parse('file:///tmp/test.zpln'),
+                getCells: () => [],
+            };
+            await kernel.syncNote(fakeNote as any);
+            assert.strictEqual(warningShown, true);
+
+            (vscode.window as any).showWarningMessage = origShowWarning;
+        });
+
+        it('marks note as syncing during operation', async () => {
+            const service = createMockService({
+                getInfo: async () => ({
+                    data: { body: { paragraphs: [] } },
+                }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const fakeNote = {
+                metadata: { id: 'n1', name: 'test' },
+                uri: vscode.Uri.parse('file:///tmp/test.zpln'),
+                getCells: () => [],
+            };
+
+            // During syncNote the note should be registered as syncing
+            // After completion it should be unregistered
+            await kernel.syncNote(fakeNote as any);
+            assert.strictEqual(kernel.isNoteSyncing(fakeNote as any), false);
+        });
+
+        it('handles undefined serverNote gracefully', async () => {
+            const service = createMockService({
+                getInfo: async () => ({ status: 404 }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+
+            // Suppress error message
+            const origShowError = vscode.window.showErrorMessage;
+            (vscode.window as any).showErrorMessage = () => Promise.resolve(undefined);
+
+            const fakeNote = {
+                metadata: { id: 'n1', name: 'test' },
+                uri: vscode.Uri.parse('file:///tmp/test.zpln'),
+                getCells: () => [],
+            };
+
+            await kernel.syncNote(fakeNote as any);
+            assert.strictEqual(kernel.isNoteSyncing(fakeNote as any), false);
+
+            (vscode.window as any).showErrorMessage = origShowError;
+        });
+    });
+
+    // ── autoDetectCellLanguage ──────────────────────────────────────────
+
+    describe('autoDetectCellLanguage', () => {
+
+        it('does nothing when cell has no interpreter magic', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({
+                status: 'READY',
+                text: 'no magic here\n',
+            });
+            // Should not throw
+            await kernel.autoDetectCellLanguage(cell as any);
+        });
+
+        it('does nothing when interpreter cache is not available', async () => {
+            kernel = new ZeppelinKernel(context);
+            const cell = createMockCell({
+                status: 'READY',
+                text: '%python\nprint("hello")\n',
+            });
+            // Cache is undefined (no service, not activated)
+            await kernel.autoDetectCellLanguage(cell as any);
+        });
+    });
+
+    // ── createParagraph ─────────────────────────────────────────────────
+
+    describe('createParagraph', () => {
+
+        it('calls service.createParagraph and updates cell metadata', async () => {
+            let createCalled = false;
+            const service = createMockService({
+                createParagraph: async () => {
+                    createCalled = true;
+                    return { data: { body: 'para_new_id' } };
+                },
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+
+            const result = await kernel.createParagraph(cell as any);
+            assert.strictEqual(createCalled, true);
+            assert.ok(result);
+        });
+    });
+
+    // ── updateParagraphText ─────────────────────────────────────────────
+
+    describe('updateParagraphText', () => {
+
+        it('calls service and polls cell metadata update', async () => {
+            let updateTextCalled = false;
+            const service = createMockService({
+                updateParagraphText: async () => {
+                    updateTextCalled = true;
+                    return { data: { body: { status: 'READY' } } };
+                },
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const cell = createMockCell({ status: 'READY' });
+
+            await kernel.updateParagraphText(cell as any);
+            assert.strictEqual(updateTextCalled, true);
+        });
+    });
+
+    // ── getNoteInfo ─────────────────────────────────────────────────────
+
+    describe('getNoteInfo', () => {
+
+        it('returns server note data on success', async () => {
+            const serverNote = { id: 'n1', paragraphs: [] };
+            const service = createMockService({
+                getInfo: async () => ({ data: { body: serverNote } }),
+            });
+            kernel = new ZeppelinKernel(context, service);
+            const fakeNote = { metadata: { id: 'n1' } };
+
+            const result = await kernel.getNoteInfo(fakeNote as any);
+            assert.deepStrictEqual(result, serverNote);
+        });
+    });
+});


### PR DESCRIPTION
### Added
- Comprehensive test suite for `notebookKernel.ts` (67 tests covering lifecycle, sync, conflict resolution, paragraph CRUD, mutex guards, and more).
- Auto-detect cell language from Magic commands using a cached interpreter map populated on kernel activation ([#39](https://github.com/allen-li1231/zeppelin-vscode/issues/39)).
- Session-expiry handler: prompts re-login or server change when the Zeppelin session expires mid-use.

### Fixed
- Operator precedence bug in `getNoteInfo` warning message — ternary was swallowed by string concatenation.
- Missing `break` statements in `parseCellOutputsToParagraphResult` switch, causing fall-through to wrong output types.
- Regex in `notebookSerializer` using `new RegExp` string constructor that silently matched nothing (replaced with regex literal).
- Race conditions in notebook kernel: metadata updates applied instantly after `doUpdateVisibleCells`; cell status bar triggered immediately on network errors.
- Incorrect interpreter ID format in cell status detection.

### Enhancement
- Refactor multi-level logging, configurable in settings and instead of printing to console, outputs are now in VSCode output channel.
- `updateMutex` and `editMutex` made private; developer now use `isEditLocked()` / `isUpdateLocked()` accessor methods.
