### PR TITLE
Various Bugs Fixed in Execution According To the Refactored syncNote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,5 +350,9 @@ All notable changes to the "zeppelin-vscode" extension will be documented in thi
 ## [0.2.25] - 2026-06-22
 
 ### Fixed
-- Missing await on runParagraph calls causing no output on remote connections (all concurrency modes).
-- Missing execution.start() in the sync execution path.
+- Missing `await` on `runParagraph` calls causing no output on remote connections (all concurrency modes).
+- Missing `execution.start()` in the sync execution path.
+- Leaked `NotebookCellExecution` in `_doExecutionAsync`: when a paragraph was already running or undefined, the early return abandoned the VS Code execution object without calling `start()`/`end()`, causing a perpetual pending spinner and blocking future runs on that cell.
+- Missing `await` on `updatePollingParagraphsDirect()` in `trackExecution`, causing `getParagraphInfo()` to read stale server state before pending local edits were pushed.
+- `NaN` start time passed to `execution.start()` in `resumeExecutionStatus` when `cell.metadata.dateStarted` was undefined; now falls back to `Date.now()`.
+- Redundant nested condition check in `trackExecution` simplified (inner `if` was always true when reached).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,3 +345,10 @@ All notable changes to the "zeppelin-vscode" extension will be documented in thi
 ### Enhancement
 - [Refactor multi-level logging, configurable in settings and instead of printing to console, outputs are now in VSCode output channel](https://github.com/allen-li1231/zeppelin-vscode/commit/a0f743e1f57a178716ceb7fb90cf7a904c5bef5e).
 - [`updateMutex` and `editMutex` made private; developer now use `isEditLocked()` / `isUpdateLocked()` accessor methods](https://github.com/allen-li1231/zeppelin-vscode/commit/76471af69fcf77b137e0fbc807636d1d45480fbe).
+
+
+## [0.2.25] - 2026-06-22
+
+### Fixed
+- Missing await on runParagraph calls causing no output on remote connections (all concurrency modes).
+- Missing execution.start() in the sync execution path.

--- a/src/component/execution.ts
+++ b/src/component/execution.ts
@@ -543,6 +543,15 @@ export class ExecutionManager
             return false;
         }
 
+        // Guard against creating a duplicate execution for a cell
+        // that already has an active one (e.g. triggered by syncNote
+        // while a previous run is still in flight).
+        if (this.getExecutionByParagraphId(cell.metadata.id))
+        {
+            logger.debug("_doExecutionSync: skipping, execution already exists for cell", cell);
+            return true;
+        }
+
         await this.kernel.updatePollingParagraphsDirect();
 
         if (cell.metadata.status === 404)
@@ -566,6 +575,10 @@ export class ExecutionManager
         });
 
         execution.start(Date.now());
+        // Register immediately so syncNote/resumeExecutionStatus can
+        // find this execution during the await below, preventing a
+        // duplicate createNotebookCellExecution for the same cell.
+        this.registerTrackExecution(execution);
 
         try
         {
@@ -573,6 +586,7 @@ export class ExecutionManager
         }
         catch (err)
         {
+            this.unregisterTrackExecution(execution);
             let cellOutput: vscode.NotebookCellOutput;
 
             if (err instanceof AxiosError && err.code === "ERR_CANCELED")
@@ -596,7 +610,6 @@ export class ExecutionManager
             }
             return false;
         }
-        this.registerTrackExecution(execution);
 
         return true;
     }
@@ -690,17 +703,25 @@ export class ExecutionManager
         let execution: ZeppelinExecution | undefined =
             this.getExecutionByParagraphId(cell.metadata.id);
 
-        let startTime: number | undefined = this.
-            getExecutionStartTimeByParagraphId(cell.metadata.id);
-
-        if (execution !== undefined)
+        // If an active (non-resolved) execution already exists for this
+        // cell, keep tracking it — but still sync remote outputs so the
+        // cell reflects the latest server state.
+        if (execution !== undefined
+            && execution.state !== ZeppelinExecutionState.resolved)
         {
-            this.unregisterTrackExecution(execution);
-            if (execution.state === ZeppelinExecutionState.started)
+            logger.debug(
+                "resumeExecutionStatus: keep existing execution",
+                execution
+            );
+            if (serverCell?.outputs)
             {
-                execution.end(undefined);
+                execution.replaceOutput(serverCell.outputs);
             }
+            this.registerTrackExecution(execution);
+            return;
         }
+
+        let startTime: number | undefined = execution?.startTime;
 
         let newExecution = new ZeppelinExecution(this.kernel, cell);
         newExecution.token.onCancellationRequested(_ =>
@@ -741,6 +762,11 @@ export class ExecutionManager
         }
         else
         {
+            // Still sync remote outputs for RUNNING/PENDING cells
+            if (serverCell?.outputs)
+            {
+                newExecution.replaceOutput(serverCell.outputs);
+            }
             this.registerTrackExecution(newExecution);
         }
     }

--- a/src/component/execution.ts
+++ b/src/component/execution.ts
@@ -312,7 +312,7 @@ export class ExecutionManager
 
         if (this.kernel.hasPendingParagraphUpdate(execution.cell))
         {
-            this.kernel.updatePollingParagraphsDirect();
+            await this.kernel.updatePollingParagraphsDirect();
         }
 
         if (execution.state === ZeppelinExecutionState.resolved)
@@ -353,12 +353,8 @@ export class ExecutionManager
         if (paragraph.status !== "PENDING"
             && execution.state === ZeppelinExecutionState.init)
         {
-            let startTime: number = Date.now();
-            if (execution.state === ZeppelinExecutionState.init)
-            {
-                execution.start(startTime);
-                this.registerTrackExecution(execution);
-            }
+            execution.start(Date.now());
+            this.registerTrackExecution(execution);
         }
 
         let pbText: string = '';
@@ -644,6 +640,10 @@ export class ExecutionManager
             {
                 logger.debug("_doExecutionAsync omit running/non-existent paragraph",
                     paragraph);
+                // Properly dispose the VS Code execution to avoid
+                // a leaked pending spinner and blocking future runs.
+                execution.start(Date.now());
+                execution.end(undefined, Date.now());
                 return
             }
             else 
@@ -717,7 +717,7 @@ export class ExecutionManager
         }
         else if (serverCell?.metadata?.status !== "PENDING")
         {
-            startTime = Date.parse(cell.metadata.dateStarted);
+            startTime = Date.parse(cell.metadata.dateStarted) || Date.now();
             newExecution.start(startTime);
             this.registerTrackExecution(newExecution);
         }

--- a/src/component/execution.ts
+++ b/src/component/execution.ts
@@ -569,9 +569,11 @@ export class ExecutionManager
             return this._cancelToken(execution);
         });
 
+        execution.start(Date.now());
+
         try
         {
-            this.kernel.runParagraph(cell, true);
+            await this.kernel.runParagraph(cell, true);
         }
         catch (err)
         {
@@ -646,7 +648,7 @@ export class ExecutionManager
             }
             else 
             {
-                this.kernel.runParagraph(cell, false);
+                await this.kernel.runParagraph(cell, false);
             }
         }
         catch (err)

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -883,6 +883,14 @@ export class ZeppelinKernel
 
         // if (cell.document.languageId !== serverCellData.languageId) { return true; }
 
+        // Skip results comparison for cells with active executions —
+        // the execution manager handles output updates independently
+        // and cell.metadata.results may be stale until execution ends.
+        if (this._executionManager?.getExecutionByParagraphId(serverParagraph.id))
+        {
+            return false;
+        }
+
         // Compare execution results stored in metadata
         let localResults = cell.metadata.results;
         let serverResults = serverParagraph.results;

--- a/src/test/suite/execution.test.ts
+++ b/src/test/suite/execution.test.ts
@@ -316,6 +316,97 @@ describe('ExecutionManager Test Suite', () => {
         });
     });
 
+    // ── resumeExecutionStatus ────────────────────────────────────────────────
+
+    describe('resumeExecutionStatus', () => {
+
+        it('keeps existing started execution instead of creating a new one', async () => {
+            const cell = createMockCell({ id: 'para_500', status: 'RUNNING' });
+            const execution = new ZeppelinExecution(kernel as any, cell as any);
+            execution.start(Date.now());
+            manager.registerTrackExecution(execution);
+
+            let createCallCount = 0;
+            const origCreate = kernel._controller.createNotebookCellExecution;
+            kernel._controller.createNotebookCellExecution = (c: any) => {
+                createCallCount++;
+                return origCreate(c);
+            };
+
+            const serverCell = new vscode.NotebookCellData(
+                vscode.NotebookCellKind.Code, '%python\\nprint(\"hello\")\\n', 'python'
+            );
+            serverCell.metadata = { id: 'para_500', status: 'RUNNING' };
+
+            await manager.resumeExecutionStatus(cell as any, serverCell);
+
+            // The original execution should still be tracked
+            assert.strictEqual(
+                manager.getExecutionByParagraphId('para_500'),
+                execution
+            );
+            // No new execution should have been created
+            assert.strictEqual(createCallCount, 0);
+            assert.strictEqual(execution.state, STATE_STARTED);
+        });
+
+        it('keeps existing init-state execution instead of creating a new one', async () => {
+            const cell = createMockCell({ id: 'para_501', status: 'PENDING' });
+            const execution = new ZeppelinExecution(kernel as any, cell as any);
+            manager.registerTrackExecution(execution);
+
+            let createCallCount = 0;
+            const origCreate = kernel._controller.createNotebookCellExecution;
+            kernel._controller.createNotebookCellExecution = (c: any) => {
+                createCallCount++;
+                return origCreate(c);
+            };
+
+            const serverCell = new vscode.NotebookCellData(
+                vscode.NotebookCellKind.Code, '%python\\nprint(\"hello\")\\n', 'python'
+            );
+            serverCell.metadata = { id: 'para_501', status: 'PENDING' };
+
+            await manager.resumeExecutionStatus(cell as any, serverCell);
+
+            assert.strictEqual(
+                manager.getExecutionByParagraphId('para_501'),
+                execution
+            );
+            assert.strictEqual(createCallCount, 0);
+            assert.strictEqual(execution.state, STATE_INIT);
+        });
+
+        it('creates new execution when previous one is resolved', async () => {
+            const cell = createMockCell({
+                id: 'para_502', status: 'FINISHED',
+            });
+            (cell.metadata as any).dateStarted = new Date().toISOString();
+            (cell.metadata as any).dateFinished = new Date().toISOString();
+
+            const oldExecution = new ZeppelinExecution(kernel as any, cell as any);
+            oldExecution.start(Date.now());
+            oldExecution.end(true, Date.now());
+            manager.registerTrackExecution(oldExecution);
+
+            const serverCell = new vscode.NotebookCellData(
+                vscode.NotebookCellKind.Code, '%python\\nprint(\"hello\")\\n', 'python'
+            );
+            serverCell.metadata = { id: 'para_502', status: 'FINISHED' };
+            serverCell.outputs = [
+                new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text('hello')
+                ])
+            ];
+
+            await manager.resumeExecutionStatus(cell as any, serverCell);
+
+            const newExecution = manager.getExecutionByParagraphId('para_502');
+            // A new execution should have been created (old one was resolved)
+            assert.ok(newExecution === undefined || newExecution !== oldExecution);
+        });
+    });
+
     // ── trackExecution ──────────────────────────────────────────────────────
 
     describe('trackExecution', () => {


### PR DESCRIPTION
### Fixed
- [Missing `await` on `runParagraph` calls causing no output on remote connections](https://github.com/allen-li1231/zeppelin-vscode/commit/f83a33ca93cfcbee5f3520efc1e0727fd6318bcd), in response to [#38](https://github.com/allen-li1231/zeppelin-vscode/issues/38).
- [False "Remote Changed" sync conflict triggered after switching away from a notebook with a running cell and back](https://github.com/allen-li1231/zeppelin-vscode/commit/2b011c39b7486e77d833ca2e05757d635f6c42c5), caused by stale `cell.metadata.results` compared against updated server results during active execution.
- [Duplicated `createNotebookCellExecution` for the same cell in a quick switch between two notebooks that have running cells](https://github.com/allen-li1231/zeppelin-vscode/commit/19eaf1c8009649bc61cc3b52be863ceef78b4f21).
- [Missing `execution.start()` in the sync execution path](https://github.com/allen-li1231/zeppelin-vscode/commit/67401170ed3a3618e849d5e5613ce84d0ced67ea).
- [Leaked `NotebookCellExecution` in `_doExecutionAsync`: when a paragraph was already running or undefined](https://github.com/allen-li1231/zeppelin-vscode/commit/67401170ed3a3618e849d5e5613ce84d0ced67ea), the early return abandoned the VS Code execution object without calling `start()`/`end()`, causing a perpetual pending spinner and blocking future runs on that cell.
- [Missing `await` on `updatePollingParagraphsDirect()` in `trackExecution`](https://github.com/allen-li1231/zeppelin-vscode/commit/f83a33ca93cfcbee5f3520efc1e0727fd6318bcd), causing `getParagraphInfo()` to read stale server state before pending local edits were pushed.
- [`NaN` start time passed to `execution.start()` in `resumeExecutionStatus` when `cell.metadata.dateStarted` was undefined; now falls back to `Date.now()`](https://github.com/allen-li1231/zeppelin-vscode/commit/67401170ed3a3618e849d5e5613ce84d0ced67ea).
